### PR TITLE
feat: complete global sensitivity multiplier integration with schema …

### DIFF
--- a/main.js
+++ b/main.js
@@ -282,7 +282,15 @@ function buildMainThemeMenuItems() {
     click: () => updateSettings({ selectedTheme: themeOption.value })
   }));
 }
-
+function getNumericSensitivity(level) {
+  switch (level) {
+    case "low": return 0.5;
+    case "high": return 2.0;
+    case "medium":
+    default:
+      return 1.0;
+  }
+}
 function buildAmbientWaveMenuItems() {
   const ambientSettings = visualizerSettings.ambientWave;
 
@@ -310,7 +318,9 @@ function buildAmbientWaveMenuItems() {
         label: level[0].toUpperCase() + level.slice(1),
         type: "radio",
         checked: ambientSettings.sensitivity === level,
-        click: () => updateSettings({ ambientWave: { sensitivity: level } })
+        click: () => updateSettings({ 
+          globalSensitivity: getNumericSensitivity(level), // Update your global field!
+          ambientWave: { sensitivity: level } })
       }))
     },
     {
@@ -362,7 +372,9 @@ function buildReactiveBorderMenuItems() {
         label: level[0].toUpperCase() + level.slice(1),
         type: "radio",
         checked: reactiveSettings.intensity === level,
-        click: () => updateSettings({ reactiveBorder: { intensity: level } })
+        click: () => updateSettings({ 
+          globalSensitivity: getNumericSensitivity(level), // Update your global field!
+          reactiveBorder: { intensity: level }})
       }))
     },
     {

--- a/main.js
+++ b/main.js
@@ -282,15 +282,7 @@ function buildMainThemeMenuItems() {
     click: () => updateSettings({ selectedTheme: themeOption.value })
   }));
 }
-function getNumericSensitivity(level) {
-  switch (level) {
-    case "low": return 0.5;
-    case "high": return 2.0;
-    case "medium":
-    default:
-      return 1.0;
-  }
-}
+
 function buildAmbientWaveMenuItems() {
   const ambientSettings = visualizerSettings.ambientWave;
 
@@ -318,9 +310,7 @@ function buildAmbientWaveMenuItems() {
         label: level[0].toUpperCase() + level.slice(1),
         type: "radio",
         checked: ambientSettings.sensitivity === level,
-        click: () => updateSettings({ 
-          globalSensitivity: getNumericSensitivity(level), // Update your global field!
-          ambientWave: { sensitivity: level } })
+        click: () => updateSettings({ ambientWave: { sensitivity: level } })
       }))
     },
     {
@@ -372,9 +362,7 @@ function buildReactiveBorderMenuItems() {
         label: level[0].toUpperCase() + level.slice(1),
         type: "radio",
         checked: reactiveSettings.intensity === level,
-        click: () => updateSettings({ 
-          globalSensitivity: getNumericSensitivity(level), // Update your global field!
-          reactiveBorder: { intensity: level }})
+        click: () => updateSettings({ reactiveBorder: { intensity: level } })
       }))
     },
     {
@@ -892,6 +880,21 @@ function refreshTrayMenu() {
     {
       label: helperConnected ? "Audio Capture: Live" : "Audio Capture: Fallback",
       enabled: false
+    },
+    { type: "separator" },
+    {
+      label: "Global Sensitivity",
+      submenu: [
+        { label: "0.5x (Quiet)", value: 0.5 },
+        { label: "1.0x (Normal)", value: 1.0 },
+        { label: "1.5x (Loud)", value: 1.5 },
+        { label: "2.0x (Aggressive)", value: 2.0 }
+      ].map((opt) => ({
+        label: opt.label,
+        type: "radio",
+        checked: visualizerSettings.globalSensitivity === opt.value,
+        click: () => updateSettings({ globalSensitivity: opt.value })
+      }))
     },
     { type: "separator" },
     {

--- a/renderer.js
+++ b/renderer.js
@@ -659,10 +659,16 @@ if (window.audioBridge) {
       latestSource = payload.source || "unknown";
       lastPayloadValue = payload.value;
 
-      // 1. Fetch the sensitivity multiplier safely from the active visualizerState
-      const globalSensitivity = visualizerState?.globalSensitivity ?? 1.0;
+      // 1. Fetch the sensitivity value from state
+      let rawSensitivity = visualizerState?.globalSensitivity;
 
-      // 2. Scale the raw incoming audio value by your multiplier calculation
+      // 2. Validate and clamp runtime boundaries right before calculation path
+      let globalSensitivity = 1.0;
+      if (typeof rawSensitivity === "number" && Number.isFinite(rawSensitivity)) {
+        globalSensitivity = Math.min(Math.max(rawSensitivity, 0.1), 5.0);
+      }
+
+      // 3. Scale the incoming audio level safely
       const scaledValue = payload.value * globalSensitivity;
 
       const helperDriven = latestSource === "helper";

--- a/renderer.js
+++ b/renderer.js
@@ -485,6 +485,9 @@ function applySettings(nextSettings) {
     }
   };
 
+  if (!nextSettings) return;
+    visualizerState.globalSensitivity = nextSettings.globalSensitivity ?? 1.0;
+
   if (!["ambientWave", "reactiveBorder", "flowBorder", "sideBars", "flatRipples", "dotParticles", "rippleFlow", "snowBubbleParticles", "edgeCrystals"].includes(visualizerState.selectedTheme)) {
     visualizerState.selectedTheme = "ambientWave";
   }
@@ -655,12 +658,22 @@ if (window.audioBridge) {
     if (payload && typeof payload.value === "number") {
       latestSource = payload.source || "unknown";
       lastPayloadValue = payload.value;
+
+      // 1. Fetch the sensitivity multiplier safely from the active visualizerState
+      const globalSensitivity = visualizerState?.globalSensitivity ?? 1.0;
+
+      // 2. Scale the raw incoming audio value by your multiplier calculation
+      const scaledValue = payload.value * globalSensitivity;
+
+      const helperDriven = latestSource === "helper";
       incomingLevel = latestSource === "helper"
-        ? clamp01(payload.value * getActiveAudioMultiplier())
-        : clamp01(payload.value);
+        ? clamp01(scaledValue * getActiveAudioMultiplier())
+        : clamp01(scaledValue);
     }
   });
 }
+
+
 
 if (window.visualizerSettings) {
   window.visualizerSettings.onChange((nextSettings) => {

--- a/settingsStore.js
+++ b/settingsStore.js
@@ -3,6 +3,7 @@ const path = require("path");
 
 const DEFAULT_SETTINGS = Object.freeze({
   selectedTheme: "ambientWave",
+  globalSensitivity: 1.0,
   ambientWave: Object.freeze({
     tone: "blue",
     sensitivity: "medium",
@@ -93,6 +94,7 @@ function createDefaultSettings() {
   return {
     selectedTheme: DEFAULT_SETTINGS.selectedTheme,
     ambientWave: { ...DEFAULT_SETTINGS.ambientWave },
+    globalSensitivity: DEFAULT_SETTINGS.globalSensitivity ,
     reactiveBorder: { ...DEFAULT_SETTINGS.reactiveBorder },
     flowBorder: { ...DEFAULT_SETTINGS.flowBorder },
     sideBars: { ...DEFAULT_SETTINGS.sideBars },
@@ -275,6 +277,7 @@ function sanitizeSettings(input = {}) {
 
   return {
     selectedTheme: pick(source.selectedTheme, VALID_MAIN_THEMES, DEFAULT_SETTINGS.selectedTheme),
+    globalSensitivity: typeof input.globalSensitivity === 'number' ? source.globalSensitivity : DEFAULT_SETTINGS.globalSensitivity,
     ambientWave: sanitizeAmbientWave(source.ambientWave),
     reactiveBorder: sanitizeReactiveBorder(source.reactiveBorder),
     flowBorder: sanitizeFlowBorder(source.flowBorder),

--- a/settingsStore.js
+++ b/settingsStore.js
@@ -275,9 +275,16 @@ function migrateLegacySettings(input = {}) {
 function sanitizeSettings(input = {}) {
   const source = migrateLegacySettings(input);
 
+  // 1. Enforce strict type validation and numeric finite boundaries
+  let safeSensitivity = 1.0; // Production default fallback
+  if (typeof source.globalSensitivity === 'number' && Number.isFinite(source.globalSensitivity)) {
+    // 2. Enforce a safe range clamp between 0.1x (minimum) and 5.0x (maximum)
+    safeSensitivity = Math.min(Math.max(source.globalSensitivity, 0.1), 5.0);
+  }
+
   return {
     selectedTheme: pick(source.selectedTheme, VALID_MAIN_THEMES, DEFAULT_SETTINGS.selectedTheme),
-    globalSensitivity: typeof input.globalSensitivity === 'number' ? source.globalSensitivity : DEFAULT_SETTINGS.globalSensitivity,
+    globalSensitivity: safeSensitivity, // Use the securely validated value
     ambientWave: sanitizeAmbientWave(source.ambientWave),
     reactiveBorder: sanitizeReactiveBorder(source.reactiveBorder),
     flowBorder: sanitizeFlowBorder(source.flowBorder),


### PR DESCRIPTION
**Related Issue**
Fixes #3 

**Description**
This Pull Request resolves the issue requesting a global sensitivity adjustment for the visualizer. Previously, sensitivity configurations were handled individually or fell back to hardcoded defaults. This change introduces a globalSensitivity key at the application schema layer, allowing users to universally scale audio responsiveness across all active themes.

**Key Changes**
1.`settingsStore.js`: Added `globalSensitivity` (defaulting to 1.0) to `DEFAULT_SETTINGS` and updated `sanitizeSettings` to correctly handle and validate numeric values during initialization and configuration loading. Fixed a primitive spreading bug in `createDefaultSettings`.

2.`renderer.js:`

-      Intercepted the raw buffer stream inside the window.audioBridge.onLevel hook to process incoming values through the newly introduced multiplier (const scaledValue = payload.value * globalSensitivity).

-     Seamlessly bound the system runtime listener arrays to update visualizerState.globalSensitivity dynamically via the onChange() and get() config streams, avoiding unnecessary application reboots.

**Verification and Testing**

- Code syntax passes native ESLint standards.
- Settings successfully write to local storage as primitives without breaking the Electron schema pipeline.
- Scaled level inputs adhere safely to boundaries via the framework's native clamp01 helper utilities.
- 

**Type of Change**

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (schema correction inside createDefaultSettings)

**Checklist**
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console syntax runtime execution faults.