### PR TITLE
feat(landing): add site footer with contact and legal links

### DIFF
--- a/landing/src/App.jsx
+++ b/landing/src/App.jsx
@@ -5,6 +5,7 @@ import HeroSection from "./components/sections/HeroSection";
 import ExperienceSection from "./components/sections/ExperienceSection";
 import ThemeShowcaseSection from "./components/sections/ThemeShowcaseSection";
 import CTASection from "./components/sections/CTASection";
+import Footer from "./components/Footer";
 import Sidebar from "./components/Sidebar";
 
 const downloadUrl = import.meta.env.VITE_DOWNLOAD_URL || "/downloads/Paraline-Setup.exe";
@@ -121,6 +122,7 @@ export default function App() {
             onDownloadClick={() => trackDownloadClick("cta")}
           />
         </main>
+        <Footer />
       </div>
 
       <Analytics />

--- a/landing/src/components/Footer.jsx
+++ b/landing/src/components/Footer.jsx
@@ -1,7 +1,7 @@
 const footerLinks = [
-  { label: "Contact", href: "mailto:hello@paraline.app" },
-  { label: "Terms", href: "#terms" },
-  { label: "Privacy", href: "#privacy" },
+  { label: "Contact", href: "https://github.com/SamXop123/Paraline/issues" },
+  { label: "Terms", href: "https://github.com/SamXop123/Paraline/blob/main/README.md" },
+  { label: "Privacy", href: "https://github.com/SamXop123/Paraline/blob/main/README.md" },
 ];
 
 export default function Footer() {
@@ -17,6 +17,8 @@ export default function Footer() {
             <a
               key={link.label}
               href={link.href}
+              target={link.href.startsWith("http") ? "_blank" : undefined}
+              rel={link.href.startsWith("http") ? "noreferrer" : undefined}
               className="text-[11px] uppercase tracking-[0.28em] text-white/52 transition hover:text-white"
             >
               {link.label}

--- a/landing/src/components/Footer.jsx
+++ b/landing/src/components/Footer.jsx
@@ -1,0 +1,29 @@
+const footerLinks = [
+  { label: "Contact", href: "mailto:hello@paraline.app" },
+  { label: "Terms", href: "#terms" },
+  { label: "Privacy", href: "#privacy" },
+];
+
+export default function Footer() {
+  return (
+    <footer className="border-t border-white/5 px-6 py-10 sm:px-8">
+      <div className="mx-auto flex max-w-7xl flex-col items-center justify-between gap-6 sm:flex-row">
+        <p className="text-xs uppercase tracking-[0.35em] text-white/45">
+          © {new Date().getFullYear()} Paraline
+        </p>
+
+        <nav aria-label="Footer" className="flex flex-wrap items-center justify-center gap-6">
+          {footerLinks.map((link) => (
+            <a
+              key={link.label}
+              href={link.href}
+              className="text-[11px] uppercase tracking-[0.28em] text-white/52 transition hover:text-white"
+            >
+              {link.label}
+            </a>
+          ))}
+        </nav>
+      </div>
+    </footer>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a landing page footer with placeholder legal and contact links.

## Changes

- New `Footer` component with Contact, Terms, and Privacy links
- Render footer below main landing sections
- External links open in a new tab with safe `rel` attributes

Fixes #6