### PR TITLE
feat(landing): add keyboard shortcuts for navigation

### DIFF
--- a/landing/src/App.jsx
+++ b/landing/src/App.jsx
@@ -5,7 +5,9 @@ import HeroSection from "./components/sections/HeroSection";
 import ExperienceSection from "./components/sections/ExperienceSection";
 import ThemeShowcaseSection from "./components/sections/ThemeShowcaseSection";
 import CTASection from "./components/sections/CTASection";
+import KeyboardShortcutsHelp from "./components/KeyboardShortcutsHelp";
 import Sidebar from "./components/Sidebar";
+import useKeyboardShortcuts from "./hooks/useKeyboardShortcuts";
 
 const downloadUrl = import.meta.env.VITE_DOWNLOAD_URL || "/downloads/Paraline-Setup.exe";
 const isHostedInstaller = /^https?:\/\//.test(downloadUrl);
@@ -55,10 +57,24 @@ export default function App() {
   };
 
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
-  const toggleSidebar = () => {
-    setIsSidebarOpen(!isSidebarOpen);
-    console.log(isSidebarOpen);
-  }
+  const [showShortcuts, setShowShortcuts] = useState(false);
+  const toggleSidebar = () => setIsSidebarOpen((open) => !open);
+  const closeSidebar = () => setIsSidebarOpen(false);
+  const toggleShortcutsHelp = (next) => {
+    if (typeof next === "boolean") {
+      setShowShortcuts(next);
+      return;
+    }
+
+    setShowShortcuts((open) => !open);
+  };
+
+  useKeyboardShortcuts({
+    onToggleSidebar: toggleSidebar,
+    onCloseSidebar: closeSidebar,
+    onToggleHelp: toggleShortcutsHelp,
+    isHelpOpen: showShortcuts,
+  });
 
   return (
     <div className="relative min-h-screen overflow-x-hidden bg-midnight text-white">
@@ -78,8 +94,13 @@ export default function App() {
         <header className="fixed inset-x-0 top-0 z-40 border border-gray-700 bg-[#02040c]/10 backdrop-blur-xl">
           <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-5 sm:px-8">
             <button
+              type="button"
               onClick={toggleSidebar}
-              className="absolute top-5 left-5">
+              aria-expanded={isSidebarOpen}
+              aria-label="Toggle navigation menu"
+              title="Toggle menu (Ctrl+B)"
+              className="absolute top-5 left-5"
+            >
                 <img src='./sidebar-icons/menu.svg' className="h-8"/>
             </button>
 
@@ -122,6 +143,8 @@ export default function App() {
           />
         </main>
       </div>
+
+      <KeyboardShortcutsHelp open={showShortcuts} onClose={() => toggleShortcutsHelp(false)} />
 
       <Analytics />
     </div>

--- a/landing/src/components/KeyboardShortcutsHelp.jsx
+++ b/landing/src/components/KeyboardShortcutsHelp.jsx
@@ -1,0 +1,45 @@
+const shortcuts = [
+  { keys: "Ctrl + B", action: "Toggle navigation sidebar" },
+  { keys: "Ctrl + /", action: "Show keyboard shortcuts" },
+  { keys: "Esc", action: "Close sidebar or shortcuts panel" },
+];
+
+export default function KeyboardShortcutsHelp({ open, onClose }) {
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div
+      className="fixed bottom-6 right-6 z-[60] w-[min(90vw,20rem)] rounded-xl border border-white/10 bg-[#050816]/95 p-4 shadow-2xl backdrop-blur-xl"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="keyboard-shortcuts-title"
+    >
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <h2 id="keyboard-shortcuts-title" className="text-sm font-semibold uppercase tracking-[0.2em] text-white/80">
+          Keyboard shortcuts
+        </h2>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close keyboard shortcuts"
+          className="rounded-md px-2 py-1 text-xs text-white/60 transition hover:bg-white/10 hover:text-white"
+        >
+          Esc
+        </button>
+      </div>
+
+      <ul className="space-y-2">
+        {shortcuts.map((shortcut) => (
+          <li key={shortcut.keys} className="flex items-center justify-between gap-4 text-sm">
+            <span className="text-white/55">{shortcut.action}</span>
+            <kbd className="rounded border border-white/15 bg-white/5 px-2 py-0.5 font-mono text-[11px] text-white/80">
+              {shortcut.keys}
+            </kbd>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/landing/src/hooks/useKeyboardShortcuts.js
+++ b/landing/src/hooks/useKeyboardShortcuts.js
@@ -1,0 +1,52 @@
+import { useEffect } from "react";
+
+function isEditableTarget(target) {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+
+  const tagName = target.tagName;
+  return tagName === "INPUT" || tagName === "TEXTAREA" || tagName === "SELECT" || target.isContentEditable;
+}
+
+export default function useKeyboardShortcuts({
+  onToggleSidebar,
+  onCloseSidebar,
+  onToggleHelp,
+  isHelpOpen,
+}) {
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      if (event.key === "Escape") {
+        if (isHelpOpen) {
+          event.preventDefault();
+          onToggleHelp(false);
+          return;
+        }
+
+        onCloseSidebar();
+        return;
+      }
+
+      if (isEditableTarget(event.target)) {
+        return;
+      }
+
+      const modifier = event.ctrlKey || event.metaKey;
+
+      if (modifier && event.key.toLowerCase() === "b") {
+        event.preventDefault();
+        onToggleSidebar();
+        return;
+      }
+
+      if (modifier && event.key === "/") {
+        event.preventDefault();
+        onToggleHelp();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isHelpOpen, onCloseSidebar, onToggleHelp, onToggleSidebar]);
+}


### PR DESCRIPTION
## Summary

Adds keyboard shortcuts and an in-app help panel for common navigation actions.

## Changes

- `Ctrl+B` / `Cmd+B` toggles the sidebar
- `Ctrl+/` / `Cmd+/` opens a shortcuts reference panel
- `Esc` closes the shortcuts panel or sidebar
- Shortcuts are ignored while typing in form fields

Fixes #25