### PR TITLE
feat(landing): add footer with legal links (#6)

### DIFF
--- a/landing/src/App.jsx
+++ b/landing/src/App.jsx
@@ -5,6 +5,7 @@ import HeroSection from "./components/sections/HeroSection";
 import ExperienceSection from "./components/sections/ExperienceSection";
 import ThemeShowcaseSection from "./components/sections/ThemeShowcaseSection";
 import CTASection from "./components/sections/CTASection";
+import Footer from "./components/Footer";
 import Sidebar from "./components/Sidebar";
 
 const downloadUrl = import.meta.env.VITE_DOWNLOAD_URL || "/downloads/Paraline-Setup.exe";
@@ -120,6 +121,7 @@ export default function App() {
             isHostedInstaller={isHostedInstaller}
             onDownloadClick={() => trackDownloadClick("cta")}
           />
+          <Footer />
         </main>
       </div>
 

--- a/landing/src/components/Footer.jsx
+++ b/landing/src/components/Footer.jsx
@@ -1,0 +1,29 @@
+const footerLinks = [
+  { label: "Contact", href: "mailto:hello@paraline.app" },
+  { label: "Terms", href: "#terms" },
+  { label: "Privacy", href: "#privacy" },
+];
+
+export default function Footer() {
+  return (
+    <footer className="border-t border-white/5 px-6 py-10 sm:px-8">
+      <div className="mx-auto flex max-w-7xl flex-col items-center justify-between gap-6 sm:flex-row">
+        <p className="text-xs uppercase tracking-[0.35em] text-white/45">
+          © {new Date().getFullYear()} Paraline
+        </p>
+
+        <nav aria-label="Footer" className="flex flex-wrap items-center justify-center gap-6">
+          {footerLinks.map((link) => (
+            <a
+              key={link.label}
+              href={link.href}
+              className="text-[11px] uppercase tracking-[0.28em] text-white/52 transition hover:text-white"
+            >
+              {link.label}
+            </a>
+          ))}
+        </nav>
+      </div>
+    </footer>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `Footer` component with Contact (mailto), Terms, and Privacy placeholder links
- Render footer below CTA on the landing page

Fixes #6

## Test plan
- [ ] Footer visible at bottom of landing page
- [ ] Links styled consistently with navbar