### PR TITLE
Link sidebar navigation buttons

### DIFF
--- a/landing/src/App.jsx
+++ b/landing/src/App.jsx
@@ -109,18 +109,29 @@ export default function App() {
         </header>
 
         <main>
+          <section id="hero" className="scroll-mt-28">
           <HeroSection
             downloadUrl={downloadUrl}
             isHostedInstaller={isHostedInstaller}
             onDownloadClick={() => trackDownloadClick("hero")}
-          />
+            />
+            </section>
+            <section id="experience" className="scroll-mt-28">
           <ExperienceSection />
+
+            </section>
+            <section id="themes" className="scroll-mt-28">
           <ThemeShowcaseSection />
+
+            </section>
+            <section id="settings" className="scroll-mt-28">
+
           <CTASection
             downloadUrl={downloadUrl}
             isHostedInstaller={isHostedInstaller}
             onDownloadClick={() => trackDownloadClick("cta")}
-          />
+            />
+            </section>
         </main>
         <Footer />
       </div>

--- a/landing/src/components/Sidebar.jsx
+++ b/landing/src/components/Sidebar.jsx
@@ -41,17 +41,17 @@ export default function Sidebar({ isSidebarOpen, toggleSidebar }) {
           <div className="flex flex-col gap-1 w-full">
             <p className="text-[10px] uppercase tracking-[0.2em] text-white/30 mb-3 px-3 font-bold">Menu</p>
 
-            <SidebarItem icon="./sidebar-icons/home.svg" label="Home" active={true} />
-            <SidebarItem icon="./sidebar-icons/tools.svg" label="Installation Guide" />
-            <SidebarItem icon="./sidebar-icons/theme.svg" label="Themes" />
-            <SidebarItem icon="./sidebar-icons/settings.svg" label="Settings" />
+            <SidebarItem icon="./sidebar-icons/home.svg" label="Home" to="#hero" active onClick={toggleSidebar}/>
+            <SidebarItem icon="./sidebar-icons/tools.svg" label="Installation Guide" to="https://github.com/SamXop123/Paraline#-installation" external onClick={toggleSidebar}/>
+            <SidebarItem icon="./sidebar-icons/theme.svg" label="Themes" to="#themes" onClick={toggleSidebar}/>
+            <SidebarItem icon="./sidebar-icons/settings.svg" label="Settings" to="#settings" onClick={toggleSidebar}/>
           </div>
 
           <div className="flex flex-col gap-1 w-full mt-10">
             <p className="text-[10px] uppercase tracking-[0.2em] text-white/30 mb-3 px-3 font-bold">Support</p>
 
-            <SidebarItem icon="./sidebar-icons/customer-service.svg" label="Contact Us" />
-            <SidebarItem icon="./sidebar-icons/github-svgrepo-com.svg" label="Github" />
+            <SidebarItem icon="./sidebar-icons/customer-service.svg" label="Contact Us" to="https://github.com/SamXop123/Paraline/issues" external onClick={toggleSidebar}/>
+            <SidebarItem icon="./sidebar-icons/github-svgrepo-com.svg" label="Github" to="https://github.com/SamXop123/Paraline" external onClick={toggleSidebar} />
           </div>
         </div>
 
@@ -70,10 +70,14 @@ export default function Sidebar({ isSidebarOpen, toggleSidebar }) {
   );
 }
 
-function SidebarItem({ icon, label, active }) {
-  return (
-    <button className={`relative flex items-center w-full px-3 py-3.5 rounded-2xl transition-all duration-150 group overflow-hidden ${active ? 'bg-white/[0.08] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.1)]' : 'text-gray-400 hover:text-white hover:bg-white/[0.04]'}`}>
-      {/* Hover background highlight */}
+function SidebarItem({ icon, label,to="#",external,active,onClick }) {
+  const classes = `relative flex items-center w-full px-3 py-3.5 rounded-2xl transition-all duration-150 group overflow-hidden ${
+    active
+      ? "bg-white/[0.08] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.1)]"
+      : "text-gray-400 hover:text-white hover:bg-white/[0.04]"
+  }`;
+    const content= (
+      <>
       <div className="absolute inset-0 bg-gradient-to-r from-sky-500/0 via-sky-500/[0.03] to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-200" />
 
       {/* Active left border indicator */}
@@ -96,6 +100,23 @@ function SidebarItem({ icon, label, active }) {
           {label}
         </span>
       </div>
-    </button>
+      </>
   );
+    // <button className={`relative flex items-center w-full px-3 py-3.5 rounded-2xl transition-all duration-150 group overflow-hidden ${active ? 'bg-white/[0.08] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.1)]' : 'text-gray-400 hover:text-white hover:bg-white/[0.04]'}`}>
+    //   {/* Hover background highlight */}
+    // </button>
+if(external){
+  return(
+    <a href={to} target="_blank" rel="noopener noreferrer" onClick={onClick} className={classes}>{content}</a>
+  );
+}
+return(
+  <a
+    href={to}
+    onClick={onClick}
+    className={classes}
+    >
+      {content}
+    </a>
+)
 }


### PR DESCRIPTION
Closes #30

## Description
Linked the sidebar navigation buttons to their respective sections and external pages.

## Changes
- Added working sidebar links for Home, Themes, and Settings sections.
- Linked Installation Guide to the GitHub README installation section.
- Linked Contact Us to the repository issues page.
- Linked GitHub button to the project repository.
- Added sidebar close behavior after clicking navigation items.

## Testing
- Verified sidebar buttons are clickable.
- Verified internal section links update/scroll correctly.
- Verified external links open the correct GitHub pages.
- Verified sidebar closes after clicking a menu item.