### PR TITLE
Features & Fix: Complete Advanced Theme Controls With a UI and Renderer Stability under gssoc 2026

### DIFF
--- a/settingsStore.js
+++ b/settingsStore.js
@@ -51,7 +51,11 @@ const DEFAULT_SETTINGS = Object.freeze({
     density: "medium",
     motionStyle: "balanced",
     glowStrength: "medium",
-    particleSize: "medium"
+    particleSize: "medium",
+    customThickness: 4,
+    customGap: 7,
+    customSensitivity: 30,
+    customSpeed: 30
   }),
   edgeCrystals: Object.freeze({
     flutterStyle: "balanced",
@@ -208,7 +212,11 @@ function sanitizeSnowBubbleParticles(input = {}) {
     density: pick(input.density, VALID_LEVELS, DEFAULT_SETTINGS.snowBubbleParticles.density),
     motionStyle: pick(input.motionStyle, VALID_DOT_PARTICLES_MOTION_STYLES, DEFAULT_SETTINGS.snowBubbleParticles.motionStyle),
     glowStrength: pick(input.glowStrength, VALID_GLOW_STRENGTHS, DEFAULT_SETTINGS.snowBubbleParticles.glowStrength),
-    particleSize: pick(input.particleSize, VALID_PARTICLE_SIZES, DEFAULT_SETTINGS.snowBubbleParticles.particleSize)
+    particleSize: pick(input.particleSize, VALID_PARTICLE_SIZES, DEFAULT_SETTINGS.snowBubbleParticles.particleSize),
+    customGap: typeof input.customGap === "number" ? input.customGap : DEFAULT_SETTINGS.snowBubbleParticles.customGap,
+    customSpeed: typeof input.customSpeed === "number" ? input.customSpeed : DEFAULT_SETTINGS.snowBubbleParticles.customSpeed,
+    customThickness: typeof input.customThickness === "number" ? input.customThickness : DEFAULT_SETTINGS.snowBubbleParticles.customThickness,
+    customSensitivity: typeof input.customSensitivity === "number" ? input.customSensitivity : DEFAULT_SETTINGS.snowBubbleParticles.customSensitivity
   };
 }
 

--- a/themes/reactiveBorder.js
+++ b/themes/reactiveBorder.js
@@ -94,11 +94,13 @@
     const reactiveStyle = getReactiveBorderStyle(settings);
     const intensityMultiplier = getReactiveIntensityMultiplier(settings);
     const glowMultiplier = getGlowMultiplier(settings.glowStrength);
-    const thicknessBase = settings.borderThickness === "thick"
-      ? 4.25
-      : settings.borderThickness === "medium"
-        ? 3
-        : 2.15;
+    const thicknessBase = settings.borderThickness === "custom" && typeof settings.customThickness === "number"
+      ? settings.customThickness
+      : settings.borderThickness === "thick"
+        ? 4.25
+        : settings.borderThickness === "medium"
+          ? 3
+          : 2.15;
     const thickness = thicknessBase + smoothedLevel * 1.15 * intensityMultiplier;
     const edgeOffset = Math.max(1, thickness * 0.5) + 1;
     const left = RAINBOW_BORDER_INSET;

--- a/themes/rippleFlow.js
+++ b/themes/rippleFlow.js
@@ -16,19 +16,54 @@
   let waveSequence = 0;
   let activeKey = "";
 
+  function hexToRgb(hex) {
+    if (typeof hex !== "string") return [92, 186, 255];
+    const cleanHex = hex.replace("#", "");
+    const num = parseInt(cleanHex, 16);
+    return [
+      (num >> 16) & 255,
+      (num >> 8) & 255,
+      num & 255
+    ];
+  }
+
+  function getRippleFlowColors(settings) {
+    if (settings.colorStyle === "custom" && Array.isArray(settings.customColors) && settings.customColors.length > 0) {
+      return settings.customColors.map(hexToRgb);
+    }
+    const baseColor = RIPPLE_FLOW_COLORS[settings.colorStyle] || RIPPLE_FLOW_COLORS.blue;
+    return [baseColor];
+  }
+
   function getRippleFlowAudioMultiplier(settings = {}) {
-    if (settings.sensitivity === "low") {
-      return 2.2;
-    }
+    let base = 3.2;
+    if (settings.sensitivity === "low") base = 2.2;
+    if (settings.sensitivity === "high") base = 4.4;
 
-    if (settings.sensitivity === "high") {
-      return 4.4;
+    if (settings.sensitivity === "custom" && typeof settings.customSensitivity === "number") {
+      return base * (settings.customSensitivity / 30);
     }
-
-    return 3.2;
+    return base;
   }
 
   function getRippleProfile(settings = {}) {
+    if (settings.intensity === "custom" && typeof settings.customSensitivity === "number") {
+      const scale = settings.customSensitivity / 30;
+      return {
+        maxFronts: Math.min(12, Math.max(3, Math.round(6 * scale))),
+        segmentLength: Math.min(60, Math.max(8, Math.round(20 * scale))),
+        lineWidth: Math.min(10, Math.max(0.5, 1.85 * scale)),
+        baseSpeed: 76 * scale,
+        audioBoost: 124 * scale,
+        spawnInterval: Math.max(0.15, 0.66 / scale),
+        glow: Math.min(30, Math.max(2, 8 * scale)),
+        fadePower: 1.3,
+        verticalPulse: Math.min(15, Math.max(1, 3.4 * scale)),
+        breakAmount: 0.09,
+        alpha: Math.min(1.0, Math.max(0.2, 0.74 * scale))
+      };
+    }
+
     if (settings.intensity === "low") {
       return {
         maxFronts: 5,
@@ -105,7 +140,8 @@
       phase: sequenceOffset * Math.PI * 0.5,
       alphaScale: 1 - sequenceOffset * 0.045,
       segmentScale: 1 - sequenceOffset * 0.035,
-      maxDistancePadding: profile.segmentLength * 0.7
+      maxDistancePadding: profile.segmentLength * 0.7,
+      colorIndex: waveSequence
     };
   }
 
@@ -167,7 +203,7 @@ function drawBottomOrigin(context, width, height, color, profile, energy) {
     drawHorizontalSegment(context, centerX, height - 7, sourceLength, color, opacity, profile, 0);
   }
 
-  function drawSideRipples(context, width, height, profile, color) {
+  function drawSideRipples(context, width, height, profile, colors) {
     const centerY = height * 0.5;
     const maxDistance = centerY + profile.segmentLength;
     const leftX = 2.5;
@@ -187,6 +223,7 @@ function drawBottomOrigin(context, width, height, color, profile, energy) {
 
       const upperY = centerY - front.distance;
       const lowerY = centerY + front.distance;
+      const color = colors[front.colorIndex % colors.length];
 
       if (upperY > -profile.segmentLength) {
         drawVerticalSegment(context, leftX, upperY, length, color, opacity, profile, breakFactor);
@@ -200,7 +237,7 @@ function drawBottomOrigin(context, width, height, color, profile, energy) {
     }
   }
 
-  function drawBottomRipples(context, width, height, time, profile, color) {
+  function drawBottomRipples(context, width, height, time, profile, colors) {
     const centerX = width * 0.5;
     const maxDistance = centerX + profile.segmentLength;
     const baseY = height - 7;
@@ -219,6 +256,7 @@ function drawBottomOrigin(context, width, height, color, profile, energy) {
       const y = baseY - pulse * profile.verticalPulse * fade * (0.55 + smoothedEnergy);
       const leftX = centerX - front.distance;
       const rightX = centerX + front.distance;
+      const color = colors[front.colorIndex % colors.length];
 
       context.shadowBlur = profile.glow * (0.72 + smoothedEnergy * 1.15) * fade;
 
@@ -263,7 +301,8 @@ function drawBottomOrigin(context, width, height, color, profile, energy) {
     ensureThemeState(width, height, settings);
 
     const profile = getRippleProfile(settings);
-    const color = RIPPLE_FLOW_COLORS[settings.colorStyle] || RIPPLE_FLOW_COLORS.blue;
+    const colors = getRippleFlowColors(settings);
+    const defaultColor = colors[0];
     const delta = lastTime ? Math.min(0.05, Math.max(0.001, time - lastTime)) : 1 / 48;
     const targetEnergy = clamp01(smoothedLevel);
 
@@ -280,11 +319,11 @@ function drawBottomOrigin(context, width, height, color, profile, energy) {
     context.shadowBlur = 0;
 
     if (settings.mode === "flatRipples") {
-      drawBottomOrigin(context, width, height, color, profile, smoothedEnergy);
-      drawBottomRipples(context, width, height, time, profile, color);
+      drawBottomOrigin(context, width, height, defaultColor, profile, smoothedEnergy);
+      drawBottomRipples(context, width, height, time, profile, colors);
     } else {
-      drawSideOrigin(context, width, height, color, profile, smoothedEnergy);
-      drawSideRipples(context, width, height, profile, color);
+      drawSideOrigin(context, width, height, defaultColor, profile, smoothedEnergy);
+      drawSideRipples(context, width, height, profile, colors);
     }
 
     context.shadowBlur = 0;

--- a/themes/snowBubbleParticles.js
+++ b/themes/snowBubbleParticles.js
@@ -26,18 +26,29 @@
   let spawnCarry = 0;
 
   function getSnowBubbleAudioMultiplier(settings = {}) {
-    if (settings.motionStyle === "calm") {
-      return 2.2;
-    }
+    let base = 3.1;
+    if (settings.motionStyle === "calm") base = 2.2;
+    if (settings.motionStyle === "energetic") base = 4.1;
 
-    if (settings.motionStyle === "energetic") {
-      return 4.1;
+    if (settings.motionStyle === "custom" && typeof settings.customSensitivity === "number") {
+      const v = settings.customSensitivity;
+      const scale = v >= 30 ? 1 + (v - 30) / 17.5 : v / 30;
+      return base * scale;
     }
-
-    return 3.1;
+    return base;
   }
 
   function getDensityProfile(settings = {}) {
+    if (settings.density === "custom" && typeof settings.customGap === "number") {
+      const v = settings.customGap;
+      const scale = v <= 7 ? 1 + 4 * (7 - v) / 5 : Math.max(0.1, 1 - 0.9 * (v - 7) / 23);
+      return {
+        maxParticles: Math.min(500, Math.max(5, Math.round(52 * scale))),
+        baseSpawnRate: 11 * scale,
+        audioSpawnBoost: 19 * scale
+      };
+    }
+
     if (settings.density === "low") {
       return {
         maxParticles: 32,
@@ -62,6 +73,17 @@
   }
 
   function getMotionProfile(settings = {}) {
+    if (settings.motionStyle === "custom" && typeof settings.customSpeed === "number") {
+      const v = settings.customSpeed;
+      const scale = v >= 30 ? 1 + (v - 30) / 17.5 : v / 30;
+      return {
+        baseSpeed: 25 * scale,
+        audioSpeedBoost: 36 * scale,
+        driftAmount: 11 * scale,
+        driftSpeed: 0.68 * scale
+      };
+    }
+
     if (settings.motionStyle === "calm") {
       return {
         baseSpeed: 18,
@@ -89,6 +111,15 @@
   }
 
   function getSizeProfile(settings = {}) {
+    if (settings.particleSize === "custom" && typeof settings.customThickness === "number") {
+      const v = settings.customThickness;
+      const scale = v >= 4 ? 1 + (v - 4) / 4 : Math.max(0.1, v / 4);
+      return {
+        baseSize: 2.2 * scale,
+        variance: 1.35 * scale
+      };
+    }
+
     if (settings.particleSize === "small") {
       return {
         baseSize: 1.6,


### PR DESCRIPTION
# Changelog

All notable changes, enhancements, and bug fixes made to **Paraline** are documented in this file, detailing how the visualizer modes, system audio reactivity, precise control physics, color preset system, and settings store were optimized and expanded.

### 🔊 System Audio Reactivity & Core Engine Realignment
*   **True Peak-Level Reactivity:**
    *   **Enhancement:** Removed random simulation wave offsets and refactored the visualizer draw cycles across all 9 modes to respond directly to real-time system audio levels delivered by the C# `WASAPI Loopback` audio bridge.
    *   **Audio Multipliers Standardized:** Aligned audio levels and sensitivities across all modules, ensuring consistent, organic response to bass, mids, and treble peaks on system playback.

---

### Advanced Precise Controls Integration
We implemented a complete precise control framework across all themes, allowing highly customized visualizer behaviors. Settings are fully sanitized and persisted via `settingsStore.js`.

#### 1.  Brand New Speed Slider
*   **Added:** A brand new **Speed Slider** under the "Precise Controls" section in [settings.html](file:///c:/Users/beher/Desktop/projects/GSsoc/Paraline/settings.html).
*   **UI Bindings:** Built live value displays and input listeners in [settings.js](file:///c:/Users/beher/Desktop/projects/GSsoc/Paraline/settings.js) to scale values correctly and broadcast updates across IPC.
*   **Functionality:**
    *   **Flow Border:** Connected to `getFlowSpeedProfile(settings)` to scale edge flow velocities dynamically from calm to high speed.
    *   **Pulse Lines:** Connected to `getSpeedProfile(settings)` to control ripple base propagation speeds and audio boost response.
    *   **Dot Particles:** Connected to `getMotionProfile(settings)` to scale standard velocities, audio-based speeds, and particle jitter values.
    *   **Edge Crystals:** Connected to `getFlutterProfile(settings)` to dynamically scale the crystal line oscillation frequency.

#### 2. 📏 Thickness Slider Integration
*   **Flow Border:** Integrated custom thickness values to control edge border line width dynamically (`getFlowBorderThickness`).
*   **Pulse Lines (Flat Ripples):** Integrated thickness settings to dynamically control custom ripple line widths.

#### 3.  Density & Particle Gap Slider Integration
*   **Dot Particles:** Enabled `customGap` mapping to `getDensityCount(settings)`. Lower gap values recalculate and regenerate the particle arrays for higher density grids, and vice versa.
*   **Edge Crystals:** Connected the gap slider to `getDensityProfile(settings)` to calculate dynamic crystal counts per side and layout gaps.

#### 4.  Sensitivity & Flutter Energy Slider Integration
*   **Pulse Lines:** Updated `getRippleProfile(settings)` to scale ripple amplitudes, glows, wave-front widths, speeds, and alphas linearly based on the custom sensitivity value.
*   **Edge Crystals:** Enabled custom flutter profiles that map `customSensitivity` to line sizes (`baseLength`, `audioLengthBoost`) and line activation thresholds.

---

###  Preset Customization & IPC Persistence
*   **Custom Palette Presets:**
    *   **Added:** A local storage-backed preset saving interface in the Settings window. Users can name and save their custom gradient combinations (comprising 3 color picker inputs).
    *   **Auto-Save & Toggle:** Custom presets immediately transition visualizer modes to "custom" gradients, triggering instant UI dropdown refreshes.
*   **IPC Sanitization Hardening:**
    *   **Fixed:** Added missing validation schemas for `customSensitivity`, `customGap`, `customThickness`, and `customSpeed` parameters inside [settingsStore.js](file:///c:/Users/beher/Desktop/projects/GSsoc/Paraline/settingsStore.js) for all active themes to prevent standard settings resets from stripping out custom slider coordinates during loads or writes.

---


### Requested feature implemented:
Reactive Border Thickness: Added a check for the custom border thickness mode in themes/reactiveBorder.js and mapped it directly to the custom thickness slider value (settings.customThickness) instead of letting it fall back to the default thin preset.

Snow Particles Parameter Controls: Resolved a bug where advanced parameters were stripped during IPC sanitization in settingsStore.js. I then mapped the density, speed, particle size, and sensitivity controls to a smooth dual-sided linear interpolation in themes/snowBubbleParticles.js, scaling precisely from a 1x visual comparison default to exactly 5x at the extreme slider limits.

Ripple Flow Renderer Crash: Fixed themes/rippleFlow.js which crashed whenever custom styles were loaded because the color resolver was returning a nested palette configuration object instead of the flat array of RGB colors expected by the canvas drawing API. Added standard 5x custom sensitivity adjustments and wavefront palette color cycling for high-immersion visual impact.