### PR TITLE
Security fix: Add file size validation and sanitization for theme pro…

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,7 +1,8 @@
 const { app, BrowserWindow, ipcMain, Menu, Tray, nativeImage, screen, shell, dialog } = require("electron");
 const path = require("path");
+const fs = require("fs");
 const { createAudioBridge } = require("./audioBridge");
-const { createDefaultSettings, createSettingsStore, createThemeDefaults } = require("./settingsStore");
+const { createDefaultSettings, createSettingsStore, createThemeDefaults, sanitizeAmbientWave, sanitizeReactiveBorder, sanitizeFlowBorder, sanitizeSideBars, sanitizeFlatRipples, sanitizeDotParticles, sanitizeRippleFlow, sanitizeSnowBubbleParticles, sanitizeEdgeCrystals, sanitizeSideBraids } = require("./settingsStore");
 
 let overlayWindow;
 let lastBridgeMode = null;
@@ -1303,6 +1304,14 @@ app.whenReady().then(() => {
       }
 
       const filePath = result.filePaths[0];
+
+      // Check file size (100KB limit to prevent DoS attacks)
+      const stats = fs.statSync(filePath);
+      const MAX_FILE_SIZE = 100 * 1024; // 100KB
+      if (stats.size > MAX_FILE_SIZE) {
+        return { success: false, error: "File too large. Maximum size is 100KB." };
+      }
+
       const importedProfile = JSON.parse(
         require("fs").readFileSync(filePath, "utf8")
       );
@@ -1312,10 +1321,24 @@ app.whenReady().then(() => {
         return { success: false, error: "Invalid theme profile format" };
       }
 
+      // Sanitize the imported profile to prevent prototype pollution and arbitrary property injection
+      const sanitizedProfile = {
+        ambientWave: sanitizeAmbientWave(importedProfile.ambientWave),
+        reactiveBorder: sanitizeReactiveBorder(importedProfile.reactiveBorder),
+        flowBorder: sanitizeFlowBorder(importedProfile.flowBorder),
+        sideBars: sanitizeSideBars(importedProfile.sideBars),
+        flatRipples: sanitizeFlatRipples(importedProfile.flatRipples),
+        dotParticles: sanitizeDotParticles(importedProfile.dotParticles),
+        rippleFlow: sanitizeRippleFlow(importedProfile.rippleFlow),
+        snowBubbleParticles: sanitizeSnowBubbleParticles(importedProfile.snowBubbleParticles),
+        edgeCrystals: sanitizeEdgeCrystals(importedProfile.edgeCrystals),
+        sideBraids: sanitizeSideBraids(importedProfile.sideBraids)
+      };
+
       const profileName = path.basename(filePath, ".json");
       const profiles = settingsStore.loadProfiles();
 
-      profiles[profileName] = importedProfile;
+      profiles[profileName] = sanitizedProfile;
       settingsStore.saveProfiles(profiles);
 
       return {

--- a/main.js
+++ b/main.js
@@ -2,7 +2,7 @@ const { app, BrowserWindow, ipcMain, Menu, Tray, nativeImage, screen, shell, dia
 const path = require("path");
 const fs = require("fs");
 const { createAudioBridge } = require("./audioBridge");
-const { createDefaultSettings, createSettingsStore, createThemeDefaults, sanitizeAmbientWave, sanitizeReactiveBorder, sanitizeFlowBorder, sanitizeSideBars, sanitizeFlatRipples, sanitizeDotParticles, sanitizeRippleFlow, sanitizeSnowBubbleParticles, sanitizeEdgeCrystals, sanitizeSideBraids } = require("./settingsStore");
+const { createDefaultSettings, createSettingsStore, createThemeDefaults, sanitizeSettings } = require("./settingsStore");
 
 let overlayWindow;
 let lastBridgeMode = null;
@@ -1322,18 +1322,7 @@ app.whenReady().then(() => {
       }
 
       // Sanitize the imported profile to prevent prototype pollution and arbitrary property injection
-      const sanitizedProfile = {
-        ambientWave: sanitizeAmbientWave(importedProfile.ambientWave),
-        reactiveBorder: sanitizeReactiveBorder(importedProfile.reactiveBorder),
-        flowBorder: sanitizeFlowBorder(importedProfile.flowBorder),
-        sideBars: sanitizeSideBars(importedProfile.sideBars),
-        flatRipples: sanitizeFlatRipples(importedProfile.flatRipples),
-        dotParticles: sanitizeDotParticles(importedProfile.dotParticles),
-        rippleFlow: sanitizeRippleFlow(importedProfile.rippleFlow),
-        snowBubbleParticles: sanitizeSnowBubbleParticles(importedProfile.snowBubbleParticles),
-        edgeCrystals: sanitizeEdgeCrystals(importedProfile.edgeCrystals),
-        sideBraids: sanitizeSideBraids(importedProfile.sideBraids)
-      };
+      const sanitizedProfile = sanitizeSettings(importedProfile);
 
       const profileName = path.basename(filePath, ".json");
       const profiles = settingsStore.loadProfiles();

--- a/settingsStore.js
+++ b/settingsStore.js
@@ -388,41 +388,53 @@ function createSettingsStore(userDataPath) {
     return cleanSettings;
   }
   function loadProfiles() {
-  try {
-    if (!fs.existsSync(profilesPath)) {
+    try {
+      if (!fs.existsSync(profilesPath)) {
+        return {};
+      }
+
+      const fileContent = fs.readFileSync(profilesPath, "utf8");
+      return JSON.parse(fileContent);
+    } catch (_error) {
       return {};
     }
-
-    const fileContent = fs.readFileSync(profilesPath, "utf8");
-    return JSON.parse(fileContent);
-  } catch (_error) {
-    return {};
   }
-}
 
-function saveProfiles(profiles) {
-  fs.mkdirSync(path.dirname(profilesPath), { recursive: true });
+  function saveProfiles(profiles) {
+    fs.mkdirSync(path.dirname(profilesPath), { recursive: true });
 
-  fs.writeFileSync(
-    profilesPath,
-    JSON.stringify(profiles, null, 2)
-  );
+    fs.writeFileSync(
+      profilesPath,
+      JSON.stringify(profiles, null, 2)
+    );
 
-  return profiles;
-}
+    return profiles;
+  }
 
   return {
-  load,
-  save,
-  loadProfiles,
-  saveProfiles,
-  path: settingsPath,
-  profilesPath
-};
+    load,
+    save,
+    loadProfiles,
+    saveProfiles,
+    path: settingsPath,
+    profilesPath
+  };
+}
 
 module.exports = {
   DEFAULT_SETTINGS,
   createDefaultSettings,
   createThemeDefaults,
-  createSettingsStore
+  createSettingsStore,
+  sanitizeSettings,
+  sanitizeAmbientWave,
+  sanitizeReactiveBorder,
+  sanitizeFlowBorder,
+  sanitizeSideBars,
+  sanitizeFlatRipples,
+  sanitizeDotParticles,
+  sanitizeRippleFlow,
+  sanitizeSnowBubbleParticles,
+  sanitizeEdgeCrystals,
+  sanitizeSideBraids
 };

--- a/settingsStore.js
+++ b/settingsStore.js
@@ -426,15 +426,5 @@ module.exports = {
   createDefaultSettings,
   createThemeDefaults,
   createSettingsStore,
-  sanitizeSettings,
-  sanitizeAmbientWave,
-  sanitizeReactiveBorder,
-  sanitizeFlowBorder,
-  sanitizeSideBars,
-  sanitizeFlatRipples,
-  sanitizeDotParticles,
-  sanitizeRippleFlow,
-  sanitizeSnowBubbleParticles,
-  sanitizeEdgeCrystals,
-  sanitizeSideBraids
+  sanitizeSettings
 };


### PR DESCRIPTION
…file import

- Add 100KB file size limit to prevent DoS attacks
- Sanitize imported theme profiles using existing validation functions
- Export theme-specific sanitization functions from settingsStore.js
- Protect against prototype pollution and arbitrary property injection
- Import sanitization functions in main.js for theme profile import

This addresses a critical security vulnerability where malicious JSON files could be imported without proper validation, potentially allowing prototype pollution attacks and arbitrary property injection.