### PR TITLE
feat: add check for updates button to about tab

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -566,6 +566,13 @@
                             </svg>
                             GitHub Repository
                         </button>
+                        <button class="btn-secondary" id="btn-updates">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <polyline points="23 4 23 10 17 10"></polyline>
+                                <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path>
+                            </svg>
+                            Check for Updates
+                        </button>
                         <button class="btn-secondary" id="btn-landing">
                             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                                 <circle cx="12" cy="12" r="10"></circle>

--- a/settings.js
+++ b/settings.js
@@ -432,6 +432,7 @@ refreshThemeProfiles();
         const btnPause = document.getElementById('btn-pause');
         const btnReload = document.getElementById('btn-reload');
         const btnGithub = document.getElementById('btn-github');
+        const btnUpdates = document.getElementById('btn-updates');
         const btnLanding = document.getElementById('btn-landing');
         btnSaveThemeProfile.addEventListener('click', async () => {
             const profileName = themeProfileNameInput.value.trim();
@@ -517,6 +518,11 @@ refreshThemeProfiles();
         btnGithub.addEventListener('click', () => {
             window.paralineApp.openExternal("https://github.com/SamXop123/Paraline");
         });
+
+        btnUpdates.addEventListener('click', () => {
+            window.paralineApp.openExternal("https://github.com/SamXop123/Paraline/releases");
+        });
+
         btnLanding.addEventListener('click', () => {
             window.paralineApp.openExternal("https://paraline.vercel.app");
         });


### PR DESCRIPTION
# Description
  This PR addresses Issue #93 by adding a "Check for Updates" button to the Settings window. This provides users with a direct way to check for the latest releases on GitHub.

## Changes
   - Modified settings.html: Added the "Check for Updates" button within the about-links container. The button uses a standard Lucide-style "refresh" SVG icon to match the existing UI.
   - Modified settings.js:
       - Initialized the btnUpdates variable.
       - Added an event listener to call window.paralineApp.openExternal with the project's releases URL.

## Technical Details
  The implementation leverages the existing Electron IPC bridge exposed via preload.js. This ensures that the external URL is opened safely in the user's default system browser without compromising the security of the Electron renderer.

## Verification
   - Manually verified the button placement and styling in the About tab.
   - Verified that clicking the button successfully triggers the external browser redirect.
   
<img width="846" height="814" alt="image" src="https://github.com/user-attachments/assets/39f84aa0-c1c4-4e6d-80e4-52aa2c3f1a40" />

 

 