### PR TITLE
border theme rendering optimization

### DIFF
--- a/themes/flowBorder.js
+++ b/themes/flowBorder.js
@@ -4,6 +4,9 @@
     computeWrappedDistance,
     getGlowMultiplier,
     resolveAnimatedColor,
+    getCachedColor,
+    buildEdgeGradient,
+    getCachedBorderGeometry,
     hexToHsl,
     applyOptimizedShadow,
     getPerformanceMultiplier
@@ -84,6 +87,22 @@
     return { base: 220, boost: 620 };
   }
 
+  // --- Pre-allocated reusable buffer for color stops ---
+  // Eliminates per-frame array/object allocations in the hot render loop.
+  // Sized for the maximum realistic segment count per edge.
+  const MAX_FLOW_STOPS = 257;
+  const flowColorStops = Array.from({ length: MAX_FLOW_STOPS }, () => ({ position: 0, color: "" }));
+
+  // Optimized: Batch all segments into a single stroke per edge using CanvasGradient.
+  // The trail/shimmer intensity variations are encoded as gradient stop opacity and
+  // lightness changes, preserving the flowing animation while reducing draw calls
+  // from O(segments) to O(1) per edge.
+  //
+  // Tradeoff: Canvas does not support per-segment lineWidth within a single stroke.
+  // The original code varied width per segment (~0.7-0.9px boost on trail segments).
+  // We use the weighted-average trail strength for the edge's lineWidth, which closely
+  // approximates the visual weight. The trail effect is primarily conveyed through
+  // the color/opacity gradient, which IS fully preserved.
   function drawFlowBorderEdge(context, options) {
     const {
       x1,
@@ -104,19 +123,21 @@
 
     const edgeLength = Math.hypot(x2 - x1, y2 - y1);
     const segmentCount = Math.max(1, Math.ceil(edgeLength / segmentLength));
+    const stopCount = Math.min(segmentCount + 1, MAX_FLOW_STOPS);
+    const stopDivisor = Math.max(1, stopCount - 1);
     const leadDistance = ((travelDistance % perimeter) + perimeter) % perimeter;
     const oppositeLeadDistance = (leadDistance + perimeter * 0.5) % perimeter;
     const emphasisLength = perimeter * 0.3;
     const perfMultiplier = getPerformanceMultiplier(performanceMode);
 
-    for (let index = 0; index < segmentCount; index++) {
-      const startT = index / segmentCount;
-      const endT = (index + 1) / segmentCount;
-      const sx = x1 + (x2 - x1) * startT;
-      const sy = y1 + (y2 - y1) * startT;
-      const ex = x1 + (x2 - x1) * endT;
-      const ey = y1 + (y2 - y1) * endT;
-      const segmentDistance = startDistance + edgeLength * ((startT + endT) * 0.5);
+    // Build color stops into pre-allocated buffer and accumulate trail strength
+    let totalTrailStrength = 0;
+    let peakTrailStrength = 0;
+    let peakColor = null;
+
+    for (let index = 0; index < stopCount; index++) {
+      const t = index / stopDivisor;
+      const segmentDistance = startDistance + edgeLength * t;
       const normalizedDistance = segmentDistance / perimeter;
       const wrappedDistanceA = computeWrappedDistance(leadDistance, segmentDistance, perimeter, direction);
       const wrappedDistanceB = computeWrappedDistance(oppositeLeadDistance, segmentDistance, perimeter, direction);
@@ -128,19 +149,36 @@
       const shimmer = Math.sin(shimmerPhase * 2.1 - 0.8) * 0.5 + 0.5;
       const intensity = 0.22 + trailStrength * 0.62 + shimmer * 0.08;
       const opacity = Math.min(0.92, (0.2 + intensity * 0.5) * (0.88 + glowMultiplier * 0.18));
-      const color = resolveAnimatedColor(colorStyle, normalizedDistance, travelDistance * 0.62, opacity, intensity * 10);
+      const color = getCachedColor(colorStyle, normalizedDistance, travelDistance * 0.62, opacity, intensity * 10);
 
-      context.beginPath();
-      context.moveTo(sx, sy);
-      context.lineTo(ex, ey);
-      context.strokeStyle = color;
-      context.lineWidth = thickness + trailStrength * (0.7 + glowMultiplier * 0.2);
-      
-      const optimizedBlur = glowBlur * (0.45 + trailStrength * (0.85 + glowMultiplier * 0.2)) * perfMultiplier;
-      applyOptimizedShadow(context, color, optimizedBlur, performanceMode);
-      
-      context.stroke();
+      // Reuse pre-allocated stop object
+      flowColorStops[index].position = t;
+      flowColorStops[index].color = color;
+
+      totalTrailStrength += trailStrength;
+      if (trailStrength > peakTrailStrength) {
+        peakTrailStrength = trailStrength;
+        peakColor = color;
+      }
     }
+
+    // Create gradient along the edge and draw with a single stroke
+    const gradient = buildEdgeGradient(context, x1, y1, x2, y2, flowColorStops, stopCount);
+
+    context.beginPath();
+    context.moveTo(x1, y1);
+    context.lineTo(x2, y2);
+    context.strokeStyle = gradient;
+
+    // Use weighted-average trail strength for lineWidth (not peak — avoids bloating entire edge)
+    const avgTrailStrength = totalTrailStrength / stopCount;
+    context.lineWidth = thickness + avgTrailStrength * (0.7 + glowMultiplier * 0.2);
+
+    // Apply shadow once per edge using the peak trail color for glow
+    const optimizedBlur = glowBlur * (0.45 + peakTrailStrength * (0.85 + glowMultiplier * 0.2)) * perfMultiplier;
+    applyOptimizedShadow(context, peakColor || "transparent", optimizedBlur, performanceMode);
+
+    context.stroke();
   }
 
   function drawFlowBorder(options) {
@@ -158,13 +196,11 @@
     const glowMultiplier = getGlowMultiplier(settings.glowStrength);
     const thickness = getFlowBorderThickness(settings) + smoothedLevel * (0.95 + glowMultiplier * 0.18);
     const edgeOffset = Math.max(1, thickness * 0.5) + 1;
-    const left = RAINBOW_BORDER_INSET;
-    const top = RAINBOW_BORDER_INSET;
-    const right = Math.max(left + 1, width - edgeOffset);
-    const bottom = Math.max(top + 1, height - edgeOffset);
-    const horizontal = right - left;
-    const vertical = bottom - top;
-    const perimeter = horizontal * 2 + vertical * 2;
+
+    // Use cached border geometry — only recomputed when dimensions or offset change
+    const geo = getCachedBorderGeometry(width, height, edgeOffset);
+    const { left, top, right, bottom, horizontal, vertical, perimeter } = geo;
+
     const direction = getFlowDirectionValue(settings);
     const travelDistance = ((flowTravelDistance % perimeter) + perimeter) % perimeter;
     const segmentLength = getFlowSegmentLength(settings);

--- a/themes/reactiveBorder.js
+++ b/themes/reactiveBorder.js
@@ -2,6 +2,9 @@
   const {
     getGlowMultiplier,
     resolveAnimatedColor,
+    getCachedColor,
+    buildEdgeGradient,
+    getCachedBorderGeometry,
     hexToHsl,
     applyOptimizedShadow,
     getPerformanceMultiplier
@@ -49,6 +52,13 @@
     return base;
   }
 
+  // --- Pre-allocated reusable buffer for color stops ---
+  // Eliminates per-frame array/object allocations in the hot render loop.
+  const MAX_REACTIVE_STOPS = 257;
+  const reactiveColorStops = Array.from({ length: MAX_REACTIVE_STOPS }, () => ({ position: 0, color: "" }));
+
+  // Optimized: Batch all segments into a single stroke per edge using CanvasGradient.
+  // Reduces draw calls from O(segments) to O(1) per edge while preserving gradient colors.
   function drawReactiveBorderEdge(context, options) {
     const {
       x1,
@@ -67,29 +77,34 @@
 
     const edgeLength = Math.hypot(x2 - x1, y2 - y1);
     const segmentCount = Math.max(1, Math.ceil(edgeLength / RAINBOW_SEGMENT_LENGTH));
+    const stopCount = Math.min(segmentCount + 1, MAX_REACTIVE_STOPS);
+    const stopDivisor = Math.max(1, stopCount - 1);
     const perfMultiplier = getPerformanceMultiplier(performanceMode);
     const optimizedBlur = glowBlur * perfMultiplier;
 
-    for (let index = 0; index < segmentCount; index++) {
-      const startT = index / segmentCount;
-      const endT = (index + 1) / segmentCount;
-      const sx = x1 + (x2 - x1) * startT;
-      const sy = y1 + (y2 - y1) * startT;
-      const ex = x1 + (x2 - x1) * endT;
-      const ey = y1 + (y2 - y1) * endT;
-      const normalizedDistance = (startDistance + edgeLength * ((startT + endT) * 0.5)) / perimeter;
-      const color = resolveAnimatedColor(colorStyle, normalizedDistance, hueOffset, opacity);
-
-      context.beginPath();
-      context.moveTo(sx, sy);
-      context.lineTo(ex, ey);
-      context.strokeStyle = color;
-      context.lineWidth = thickness;
-      
-      applyOptimizedShadow(context, color, optimizedBlur, performanceMode);
-      
-      context.stroke();
+    // Build color stops into pre-allocated buffer — one per segment boundary
+    for (let index = 0; index < stopCount; index++) {
+      const t = index / stopDivisor;
+      const normalizedDistance = (startDistance + edgeLength * t) / perimeter;
+      const color = getCachedColor(colorStyle, normalizedDistance, hueOffset, opacity, 0);
+      reactiveColorStops[index].position = t;
+      reactiveColorStops[index].color = color;
     }
+
+    // Create gradient along the edge and draw with a single stroke
+    const gradient = buildEdgeGradient(context, x1, y1, x2, y2, reactiveColorStops, stopCount);
+
+    context.beginPath();
+    context.moveTo(x1, y1);
+    context.lineTo(x2, y2);
+    context.strokeStyle = gradient;
+    context.lineWidth = thickness;
+
+    // Apply shadow once per edge using the midpoint color for glow
+    const midColor = reactiveColorStops[Math.floor(stopCount / 2)].color;
+    applyOptimizedShadow(context, midColor, optimizedBlur, performanceMode);
+
+    context.stroke();
   }
 
   function drawReactiveBorder(options) {
@@ -113,13 +128,11 @@
         : 2.15;
     const thickness = thicknessBase + smoothedLevel * 1.15 * intensityMultiplier;
     const edgeOffset = Math.max(1, thickness * 0.5) + 1;
-    const left = RAINBOW_BORDER_INSET;
-    const top = RAINBOW_BORDER_INSET;
-    const right = Math.max(left + 1, width - edgeOffset);
-    const bottom = Math.max(top + 1, height - edgeOffset);
-    const horizontal = right - left;
-    const vertical = bottom - top;
-    const perimeter = horizontal * 2 + vertical * 2;
+
+    // Use cached border geometry — only recomputed when dimensions or offset change
+    const geo = getCachedBorderGeometry(width, height, edgeOffset);
+    const { left, top, right, bottom, horizontal, vertical, perimeter } = geo;
+
     const speed = 32 + smoothedLevel * 180 * intensityMultiplier;
     const hueOffset = time * speed;
     const glowBlur = (7 + smoothedLevel * 10) * glowMultiplier;

--- a/themes/shared.js
+++ b/themes/shared.js
@@ -182,11 +182,103 @@
     }
   }
 
+  // --- Color Cache ---
+  // Avoids per-frame hsla() string allocations by caching results
+  // keyed on quantized inputs. Fixed-size to prevent memory growth.
+  // Key includes style identity (hueA/hueB/saturation/lightness) to prevent
+  // stale colors when switching between color styles (e.g. neonBlue → neonPurple).
+  const COLOR_CACHE_MAX_SIZE = 512;
+  const colorCacheMap = new Map();
+
+  function getCachedColor(style, normalizedDistance, animationOffset, opacity, lightnessBoost) {
+    // Quantize inputs to reduce unique keys while preserving visual fidelity
+    const qDist = (normalizedDistance * 100) | 0;
+    const qOffset = (animationOffset * 10) | 0;
+    const qOpacity = (opacity * 100) | 0;
+    const qBoost = (lightnessBoost * 10) | 0;
+
+    // Include style identity in key — prevents cross-style cache collisions
+    let key;
+    if (style.mode === "rainbow") {
+      key = `r:${style.saturation}:${style.lightness}:${qDist}:${qOffset}:${qOpacity}:${qBoost}`;
+    } else {
+      const qHueA = style.hueA | 0;
+      const qHueB = style.hueB | 0;
+      key = `g:${qHueA}:${qHueB}:${style.saturation}:${style.lightness}:${qDist}:${qOffset}:${qOpacity}:${qBoost}`;
+    }
+
+    const cached = colorCacheMap.get(key);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    const color = resolveAnimatedColor(style, normalizedDistance, animationOffset, opacity, lightnessBoost);
+
+    // Evict oldest entries when cache is full
+    if (colorCacheMap.size >= COLOR_CACHE_MAX_SIZE) {
+      const firstKey = colorCacheMap.keys().next().value;
+      colorCacheMap.delete(firstKey);
+    }
+
+    colorCacheMap.set(key, color);
+    return color;
+  }
+
+  // --- Gradient Builder ---
+  // Creates a CanvasLinearGradient from an array of color stops for batched edge rendering.
+  // This enables drawing an entire edge with a single stroke() call while preserving
+  // the per-segment color gradient effect.
+  // Accepts an optional `count` parameter for pre-allocated reusable arrays — callers
+  // can pass a larger buffer and specify how many stops to actually use.
+  function buildEdgeGradient(context, x1, y1, x2, y2, colorStops, count) {
+    const gradient = context.createLinearGradient(x1, y1, x2, y2);
+    const len = count !== undefined ? count : colorStops.length;
+    for (let i = 0; i < len; i++) {
+      gradient.addColorStop(colorStops[i].position, colorStops[i].color);
+    }
+    return gradient;
+  }
+
+  // --- Border Geometry Cache ---
+  // Stores precomputed border coordinates to avoid recalculation every frame.
+  // Invalidated on resize or settings change.
+  let cachedBorderGeometry = null;
+
+  function computeBorderGeometry(width, height, edgeOffset) {
+    const left = 0;
+    const top = 0;
+    const right = Math.max(left + 1, width - edgeOffset);
+    const bottom = Math.max(top + 1, height - edgeOffset);
+    const horizontal = right - left;
+    const vertical = bottom - top;
+    const perimeter = horizontal * 2 + vertical * 2;
+
+    return { left, top, right, bottom, horizontal, vertical, perimeter };
+  }
+
+  function getCachedBorderGeometry(width, height, edgeOffset) {
+    if (
+      cachedBorderGeometry &&
+      cachedBorderGeometry.width === width &&
+      cachedBorderGeometry.height === height &&
+      cachedBorderGeometry.edgeOffset === edgeOffset
+    ) {
+      return cachedBorderGeometry.geometry;
+    }
+
+    const geometry = computeBorderGeometry(width, height, edgeOffset);
+    cachedBorderGeometry = { width, height, edgeOffset, geometry };
+    return geometry;
+  }
+
   window.ParalineShared = {
     TRANSPARENT_HAZE,
     clamp01,
     getGlowMultiplier,
     resolveAnimatedColor,
+    getCachedColor,
+    buildEdgeGradient,
+    getCachedBorderGeometry,
     drawWave,
     drawGlowBand,
     drawSoftFill,


### PR DESCRIPTION
## Summary

  This PR optimizes the Flow Border and Reactive Border render paths to reduce per-frame canvas overhead on high-resolution displays.

  ## Changes Implemented

  - Replaced per-segment beginPath() / stroke() calls with one CanvasGradient stroke per edge.
  - Preserved gradient color behavior using context.createLinearGradient() instead of collapsing the border into a single solid
    color.
  - Added cached color generation for animated hsla(...) strings.
  - Included color style identity in the cache key to avoid stale colors when switching styles or custom colors.
  - Added cached border geometry so repeated border coordinate calculations are reused while dimensions/offset stay the same.
  - Reused preallocated color stop buffers to reduce hot-loop allocations.
  - Fixed capped gradient sampling so high-resolution edges still span the full 0..1 gradient range.
  - Left the existing renderer.js DPR cap unchanged, since MAX_DEVICE_SCALE = 1.25 already handles that.

  ## Before / After Rendering Work

  Approximate stroke calls per frame at 3840x2160:

  
 **Theme - Before  - After**

- Flow Border, medium segments - ~668 strokes - 4 strokes 
- Flow Border, short segments  - ~860 strokes - 4 strokes 
- Reactive Border - ~168 strokes - 4 strokes 


  ## Testing

  - Ran npm start; app launched successfully.
  - Manually verified Flow Border and Reactive Border still render animated gradients.
  - Verified gradients remain visible and do not collapse into solid strokes.
  - Verified color style switching does not reuse stale cached colors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized border rendering performance for flow and reactive elements, delivering improved visual smoothness and responsiveness during interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SamXop123/Paraline/pull/101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->