### PR TITLE
Fix simulated audio fallback timer cleanup

### DIFF
--- a/main.js
+++ b/main.js
@@ -10,6 +10,7 @@ let lastBridgeMode = null;
 let lastBridgeReason = null;
 let audioBridge;
 let fakeTimer;
+let isQuitting = false;
 let tray;
 let isPaused = false;
 let isHidden = false;
@@ -175,7 +176,12 @@ function createOverlayWindow() {
     }, 100);
   });
 
+  overlayWindow.on("close", () => {
+    stopSimulatedAudioFallback();
+  });
+
   overlayWindow.on("closed", () => {
+    stopSimulatedAudioFallback();
     overlayWindow = null;
   });
 }
@@ -274,6 +280,7 @@ function reloadVisualizer() {
     return;
   }
 
+  stopSimulatedAudioFallback();
   overlayWindow.webContents.reloadIgnoringCache();
 }
 
@@ -339,7 +346,9 @@ function applyFocusModeState() {
 }
 
 function startSimulatedAudioFallback() {
-  stopSimulatedAudioFallback();
+  if (fakeTimer) {
+    return;
+  }
 
   fakeTimer = setInterval(() => {
     const now = Date.now();
@@ -384,8 +393,10 @@ function handleAudioBridgeStatusChange(status) {
   }
   lastBridgeMode = status.mode;
   lastBridgeReason = status.reason;
-  if (status.mode !== "helper") {
+  if (status.mode !== "helper" && !isQuitting) {
     startSimulatedAudioFallback();
+  } else {
+    stopSimulatedAudioFallback();
   }
   refreshTrayMenu();
 }
@@ -1577,7 +1588,23 @@ app.on("second-instance", () => {
   }
 });
 
+app.on("before-quit", () => {
+  isQuitting = true;
+  stopSimulatedAudioFallback();
+
+  if (audioBridge) {
+    audioBridge.stop();
+  }
+});
+
+app.on("will-quit", () => {
+  stopSimulatedAudioFallback();
+});
+
 app.on("window-all-closed", () => {
+  isQuitting = true;
+  stopSimulatedAudioFallback();
+
   if (audioBridge) {
     audioBridge.stop();
   }


### PR DESCRIPTION
Stop the simulated audio fallback whenever the native helper reports that it is active again, preventing the setInterval fallback from continuing after helper recovery.

Make fallback startup idempotent so repeated simulated-mode status updates cannot create redundant intervals. Also clear the fallback during overlay close/reload and app quit paths, with an isQuitting guard so audioBridge.stop() cannot restart simulation while the app is shutting down.

Verification:

node --check main.js passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Enhanced app shutdown process with improved audio cleanup coordination to prevent resource leaks
- Fixed audio fallback behavior during visualizer reload with proper cleanup sequencing
- Improved audio bridge status handling and overlay window closure management
- Prevented duplicate audio fallback intervals for more stable audio performance
- Better app lifecycle event coordination for more reliable shutdown behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SamXop123/Paraline/pull/111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->