### PR TITLE
Add reset to default button in theme settings

### DIFF
--- a/main.js
+++ b/main.js
@@ -1455,7 +1455,7 @@ app.whenReady().then(() => {
   });
 
   ipcMain.handle("theme-profiles:reset", () => {
-    resetAllSettings();
+    resetCurrentThemeSettings();
     return getRendererSettings();
   });
 

--- a/main.js
+++ b/main.js
@@ -1455,6 +1455,11 @@ app.whenReady().then(() => {
   });
 
   ipcMain.handle("theme-profiles:reset", () => {
+    resetAllSettings();
+    return getRendererSettings();
+  });
+
+  ipcMain.handle("theme-profiles:reset-current", () => {
     resetCurrentThemeSettings();
     return getRendererSettings();
   });

--- a/preload.js
+++ b/preload.js
@@ -105,5 +105,8 @@ contextBridge.exposeInMainWorld("paralineApp", {
     ipcRenderer.invoke("theme-profiles:import"),
 
   resetThemeSettings: () =>
-    ipcRenderer.invoke("theme-profiles:reset")
+    ipcRenderer.invoke("theme-profiles:reset"),
+
+  resetActiveThemeSettings: () =>
+    ipcRenderer.invoke("theme-profiles:reset-current")
 });

--- a/settings.html
+++ b/settings.html
@@ -135,6 +135,11 @@
                     <div id="dynamic-theme-settings">
                         <!-- Populated dynamically by settings.js based on selected theme -->
                     </div>
+                        <div style="margin-top:16px;">
+                            <button id="btn-reset-theme" class="btn-secondary">
+                                Reset to Default
+                            </button>
+                    </div>
                 </div>
             </section>
 

--- a/settings.js
+++ b/settings.js
@@ -340,6 +340,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const btnExportThemeProfile = document.getElementById('btn-export-theme-profile');
     const btnImportThemeProfile = document.getElementById('btn-import-theme-profile');
     const btnResetThemeProfile = document.getElementById('btn-reset-theme-profile');
+    
 
     let presets = {
         "Ocean Blue": ["#00f2fe", "#4facfe", "#8ee2ff"],
@@ -513,6 +514,15 @@ refreshThemeProfiles();
         const btnGithub = document.getElementById('btn-github');
         const btnUpdates = document.getElementById('btn-updates');
         const btnLanding = document.getElementById('btn-landing');
+        const btnResetTheme =document.getElementById('btn-reset-theme');
+        if (btnResetTheme) {
+            btnResetTheme.addEventListener('click', async () => {
+                if (confirm("Reset theme settings to default?")) {
+                    await window.paralineApp.resetThemeSettings();
+                    location.reload();
+                }
+            });
+        }
         btnSaveThemeProfile.addEventListener('click', async () => {
             const profileName = themeProfileNameInput.value.trim();
 

--- a/settings.js
+++ b/settings.js
@@ -514,11 +514,11 @@ refreshThemeProfiles();
         const btnGithub = document.getElementById('btn-github');
         const btnUpdates = document.getElementById('btn-updates');
         const btnLanding = document.getElementById('btn-landing');
-        const btnResetTheme =document.getElementById('btn-reset-theme');
+        const btnResetTheme = document.getElementById('btn-reset-theme');
         if (btnResetTheme) {
             btnResetTheme.addEventListener('click', async () => {
                 if (confirm("Reset theme settings to default?")) {
-                    await window.paralineApp.resetThemeSettings();
+                    await window.paralineApp.resetActiveThemeSettings();
                     location.reload();
                 }
             });


### PR DESCRIPTION
## Summary
Added a "Reset to Default" button in the Theme Properties section of the Settings page.

## Changes
- Added a Reset to Default button below Theme Properties.
- Connected the button to the existing theme reset functionality.
- Added a confirmation dialog before resetting.
- Reloads the UI after reset so default values are immediately reflected.

## Issue
Closes #109

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Reset to Default" button in the Theme Properties area of Settings.
  * Button prompts for confirmation and then resets the currently active theme back to defaults.
  * After reset the UI automatically refreshes to reflect the restored theme settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SamXop123/Paraline/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->