### PR TITLE
fix(#118): validate URL scheme before calling shell.openExternal

### DIFF
--- a/main.js
+++ b/main.js
@@ -460,7 +460,21 @@ function getThemeProfiles() {
   return settingsStore.loadProfiles();
 }
 
+// Allowlist of URL schemes that may be passed to shell.openExternal.
+// Any other scheme (e.g. ms-settings:, file:, javascript:) is silently
+// rejected to prevent OS-level command execution via registered protocols.
+const ALLOWED_EXTERNAL_SCHEMES = new Set(["https:", "http:"]);
+
 function openExternalUrl(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return;
+  }
+  if (!ALLOWED_EXTERNAL_SCHEMES.has(parsed.protocol)) {
+    return;
+  }
   shell.openExternal(url).catch(() => {
     // Ignore shell open failures from tray actions.
   });


### PR DESCRIPTION
## Summary

Both the `app:open-external` IPC handler and the `visualizer-action` `open-url` path passed caller-supplied URLs directly to `shell.openExternal` without any scheme validation. On Windows, registered custom protocols such as `ms-settings:`, `ms-officecmd:`, and `search-ms:` are dispatched to the OS shell, allowing a malicious or compromised renderer to silently launch arbitrary system applications or trigger privileged OS actions without user consent. Electron's own security documentation explicitly requires scheme validation before calling `shell.openExternal`.

Closes #118

## Root Cause

```js
// Before: no scheme check in either caller
ipcMain.handle('app:open-external', (_event, url) => {
  openExternalUrl(url);
});

} else if (action === 'open-url') {
  openExternalUrl(data);  // data is renderer-supplied
}
```

`openExternalUrl` called `shell.openExternal(url)` unconditionally.

## Fix

Added an `ALLOWED_EXTERNAL_SCHEMES` allowlist (`https:` and `http:`) inside `openExternalUrl`. The function parses the URL with `new URL()` and returns early if the resulting protocol is not in the allowlist. Invalid URL strings (parse errors) also return early without reaching `shell.openExternal`. All callers go through the same central function so the guard applies uniformly.

```js
const ALLOWED_EXTERNAL_SCHEMES = new Set(["https:", "http:"]);

function openExternalUrl(url) {
  let parsed;
  try {
    parsed = new URL(url);
  } catch {
    return;
  }
  if (!ALLOWED_EXTERNAL_SCHEMES.has(parsed.protocol)) {
    return;
  }
  shell.openExternal(url).catch(() => {});
}
```

## Files Changed

- `main.js`: Added `ALLOWED_EXTERNAL_SCHEMES` constant and scheme validation at the top of `openExternalUrl`.

## How to Test

1. From renderer DevTools: `window.paralineApp.openExternal('ms-settings:')` should do nothing.
2. `window.paralineApp.openExternal('https://github.com')` should open the browser as before.
3. `window.paralineApp.openExternal('javascript:alert(1)')` should do nothing.

## Checklist

- [x] Only targets the identified vulnerability.
- [x] No functional change for callers that already supply `https:` or `http:` URLs.
- [x] No new dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security by implementing URL scheme validation for external link handling. External URLs are now restricted to HTTPS and HTTP protocols only, with invalid URLs silently blocked.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SamXop123/Paraline/pull/137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->