### PR TITLE
fix(#119, #121): validate profile names to prevent Object.prototype pollution

### DIFF
--- a/main.js
+++ b/main.js
@@ -421,7 +421,25 @@ function resetAllSettings() {
   sendVisualizerSettings();
   refreshTrayMenu();
 }
+// Reserved JavaScript property names that must not be used as object keys.
+// Using these as keys on a plain object pollutes Object.prototype and affects
+// every plain object created in the same process for the rest of its lifetime.
+const RESERVED_PROFILE_NAMES = new Set(["__proto__", "constructor", "prototype"]);
+
+// Allowlist pattern: profile names may only contain letters, digits,
+// spaces, hyphens, underscores, and parentheses (max 64 chars).
+const SAFE_PROFILE_NAME_RE = /^[A-Za-z0-9 _\-()À-ɏ]{1,64}$/;
+
+function isValidProfileName(name) {
+  if (typeof name !== "string" || name.trim() === "") return false;
+  if (RESERVED_PROFILE_NAMES.has(name)) return false;
+  return SAFE_PROFILE_NAME_RE.test(name);
+}
+
 function saveThemeProfile(profileName) {
+  if (!isValidProfileName(profileName)) {
+    return null;
+  }
   const profiles = settingsStore.loadProfiles();
 
   profiles[profileName] = visualizerSettings;
@@ -1538,7 +1556,11 @@ app.whenReady().then(() => {
       // Sanitize the imported profile to prevent prototype pollution and arbitrary property injection
       const sanitizedProfile = sanitizeSettings(importedProfile);
 
-      const profileName = path.basename(filePath, ".json");
+      const rawProfileName = path.basename(filePath, ".json");
+      if (!isValidProfileName(rawProfileName)) {
+        return { success: false, error: "Invalid profile name: the filename contains reserved or disallowed characters." };
+      }
+      const profileName = rawProfileName;
       const profiles = settingsStore.loadProfiles();
 
       profiles[profileName] = sanitizedProfile;


### PR DESCRIPTION
## Summary

Two separate code paths in `main.js` allowed attacker-controlled strings to be used as plain-object keys without validation, enabling prototype pollution of `Object.prototype` in the main process.

1. **Issue #121**: `saveThemeProfile(profileName)` used the renderer-supplied string directly as `profiles[profileName] = visualizerSettings`. Calling `window.paralineApp.saveThemeProfile('__proto__')` set `Object.prototype` properties to all current settings values, affecting every plain object created in the main process for the rest of the session.

2. **Issue #119**: The `theme-profiles:import` handler derived the profile name from the imported filename via `path.basename(filePath, '.json')`. Importing a file named `__proto__.json` triggered `profiles['__proto__'] = sanitizedProfile`, same impact as above.

Closes #119
Closes #121

## Root Cause

```js
// Issue #121 - saveThemeProfile
profiles[profileName] = visualizerSettings;  // profileName unchecked

// Issue #119 - theme-profiles:import
const profileName = path.basename(filePath, '.json');  // filename as key
profiles[profileName] = sanitizedProfile;             // no validation
```

## Fix

Added `isValidProfileName()` which rejects:
- Non-string or empty values
- Reserved JS property names: `__proto__`, `constructor`, `prototype`
- Strings that do not match the safe allowlist `[A-Za-z0-9 _\-()À-ɏ]{1,64}`

`saveThemeProfile` returns `null` early for invalid names. The import handler returns a structured `{ success: false, error }` response. The guard is defined once and applied consistently across both call sites.

```js
const RESERVED_PROFILE_NAMES = new Set(["__proto__", "constructor", "prototype"]);
const SAFE_PROFILE_NAME_RE = /^[A-Za-z0-9 _\-()À-ɏ]{1,64}$/;

function isValidProfileName(name) {
  if (typeof name !== "string" || name.trim() === "") return false;
  if (RESERVED_PROFILE_NAMES.has(name)) return false;
  return SAFE_PROFILE_NAME_RE.test(name);
}
```

## Files Changed

- `main.js`: Added `isValidProfileName` helper; applied at start of `saveThemeProfile`; applied to filename-derived name in `theme-profiles:import`.

## How to Test

1. In renderer DevTools: `window.paralineApp.saveThemeProfile('__proto__')` should return null and leave `Object.prototype` unchanged.
2. Import a file named `__proto__.json` — should return `{ success: false, error: '...' }`.
3. Normal profile names like `My Profile` or `Dark-2024` should continue to work.

## Checklist

- [x] Both issue #119 and #121 addressed with a single shared guard function.
- [x] No change to any functionality for valid profile names.
- [x] No new dependencies.