### PR TITLE
fix(#120): remove duplicate ipcMain.on listener for visualizer-settings:update

### DIFF
--- a/main.js
+++ b/main.js
@@ -1384,10 +1384,6 @@ app.whenReady().then(() => {
     return getRendererSettings();
   });
 
-  ipcMain.on("visualizer-settings:update", (event, patch) => {
-    updateSettings(patch);
-  });
-
   ipcMain.on("visualizer-action", (event, { action, data }) => {
     if (action === "toggle-paused") {
       togglePaused();


### PR DESCRIPTION
## Summary

`main.js` registered two competing listeners on the `visualizer-settings:update` IPC channel simultaneously: an `ipcMain.on` (fire-and-forget) and an `ipcMain.handle` (request-response). On every settings update from the renderer both handlers fired, calling `updateSettings(patch)` twice per message and writing the patch to disk twice. Errors thrown inside the `ipcMain.on` callback were silently discarded with no propagation back to the renderer, making the channel unreliable.

Closes #120

## Root Cause

```js
// Added first - fire-and-forget, errors swallowed
ipcMain.on('visualizer-settings:update', (event, patch) => {
  updateSettings(patch);
});

// Added later - request-response, returns updated state
ipcMain.handle('visualizer-settings:update', (_event, patch) => {
  updateSettings(patch);
  return getRendererSettings();
});
```

Both execute on every `ipcRenderer.invoke('visualizer-settings:update', patch)` call.

## Fix

Removed the `ipcMain.on` registration. The `ipcMain.handle` registration is the correct pattern for this channel: it applies the patch once, persists it, and returns the updated settings object to the renderer as the invoke reply.

## Files Changed

- `main.js`: Removed the 4-line `ipcMain.on('visualizer-settings:update', ...)` block.

## How to Test

1. Open Paraline settings and change any setting (e.g. toggle a theme option).
2. Verify the change is applied and persisted exactly once.
3. Verify the settings window reflects the updated state correctly on the same interaction.

## Checklist

- [x] Single targeted removal with no side effects on other channels.
- [x] The remaining `ipcMain.handle` registration provides full update semantics.
- [x] No new dependencies or logic changes.