### PR TITLE
fix: add validation for audio helper executable before packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
     "landing:build": "npm --prefix landing run build",
     "audio:helper:info": "powershell -NoProfile -Command \"Write-Output 'Build the helper with: dotnet build .\\audio-helper\\Paraline.AudioBridge.csproj'\"",
     "build:helper": "dotnet publish .\\audio-helper\\Paraline.AudioBridge.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o .\\build\\audio-helper",
-    "pack:win": "npm run build:helper && electron-builder --dir --win nsis --x64",
-    "dist:win": "npm run build:helper && electron-builder --win nsis --x64"
+    "pack:win": "npm run build:helper && npm run validate:helper && electron-builder --dir --win nsis --x64",
+  "dist:win": "npm run build:helper && npm run validate:helper && electron-builder --win nsis --x64",
+    "validate:helper": "node scripts/validate-helper.js"
   },
   "keywords": [
     "electron",

--- a/scripts/validate-helper.js
+++ b/scripts/validate-helper.js
@@ -1,0 +1,19 @@
+const fs = require("fs");
+const path = require("path");
+
+const helperPath = path.join(
+  process.cwd(),
+  "build",
+  "audio-helper",
+  "Paraline.AudioBridge.exe"
+);
+
+if (!fs.existsSync(helperPath)) {
+  console.error("\n❌ Audio helper executable not found.");
+  console.error(`Expected: ${helperPath}`);
+  console.error("\nRun:");
+  console.error("npm run build:helper");
+  process.exit(1);
+}
+
+console.log("✅ Audio helper executable found.");


### PR DESCRIPTION
## Closes #129

### Summary

Adds a pre-packaging validation step to ensure the audio helper executable exists before Electron packaging begins.

### Changes Made

* Added `scripts/validate-helper.js`
* Added `validate:helper` npm script
* Updated `pack:win` and `dist:win` workflows to run validation before packaging
* Added clear error output when `Paraline.AudioBridge.exe` is missing

### Why

The build configuration expects:

build/audio-helper/Paraline.AudioBridge.exe

to be available as an extra resource. If the helper build fails or the executable is missing, packaging can fail with less obvious errors.

This validation step provides an immediate and actionable error message, making packaging failures easier to diagnose.

### Testing

* Verified successful validation when the executable exists
* Verified packaging is blocked when the executable is missing
* Confirmed a clear recovery message is displayed
