### PR TITLE
feat: add complete settings backup import and export

### DIFF
--- a/main.js
+++ b/main.js
@@ -456,6 +456,23 @@ function deleteThemeProfile(profileName) {
   return profiles;
 }
 
+function duplicateThemeProfile(srcName, destName) {
+  if (
+    typeof srcName !== "string" || srcName.trim() === "" ||
+    typeof destName !== "string" || destName.trim() === "" ||
+    destName === "__proto__" || destName === "constructor" || destName === "prototype"
+  ) {
+    return null;
+  }
+  const profiles = settingsStore.loadProfiles();
+  if (!profiles[srcName]) {
+    return null;
+  }
+  profiles[destName] = JSON.parse(JSON.stringify(profiles[srcName]));
+  settingsStore.saveProfiles(profiles);
+  return profiles;
+}
+
 function getThemeProfiles() {
   return settingsStore.loadProfiles();
 }
@@ -1452,6 +1469,10 @@ app.whenReady().then(() => {
 
   ipcMain.handle("theme-profiles:delete", (_event, profileName) => {
     return deleteThemeProfile(profileName);
+  });
+
+  ipcMain.handle("theme-profiles:duplicate", (_event, srcProfileName, destProfileName) => {
+    return duplicateThemeProfile(srcProfileName, destProfileName);
   });
 
   ipcMain.handle("theme-profiles:reset", () => {

--- a/main.js
+++ b/main.js
@@ -1614,10 +1614,13 @@ app.whenReady().then(() => {
           require("fs").readFileSync(filePath, "utf8")
       );
 
-      if (!importedBackup || typeof importedBackup !== "object") {
+      if (
+          !importedBackup ||
+          typeof importedBackup !== "object" ||
+          Array.isArray(importedBackup)
+      ) {
           return { success: false, error: "Invalid backup format" };
       }
-
       const cleanSettings = sanitizeSettings(
           importedBackup.settings || {}
       );

--- a/main.js
+++ b/main.js
@@ -1624,11 +1624,32 @@ app.whenReady().then(() => {
 
       settingsStore.save(cleanSettings);
 
-      settingsStore.saveProfiles(
-          importedBackup.profiles || {}
-      );
+    const safeProfiles = {};
+
+    for (const [name, profile] of Object.entries(importedBackup.profiles || {})) {
+
+        if (
+            typeof name !== "string" ||
+            name === "__proto__" ||
+            name === "constructor" ||
+            name === "prototype"
+        ) {
+            continue;
+        }
+
+        safeProfiles[name] = sanitizeSettings(profile || {});
+    }
+
+    settingsStore.saveProfiles(safeProfiles);
 
       visualizerSettings = cleanSettings;
+
+      applyStartupSettings(visualizerSettings.launchOnStartup);
+      applyFocusModeState();
+
+      if (themeAgent) {
+          themeAgent.start();
+      }
 
       sendVisualizerSettings();
       refreshTrayMenu();

--- a/main.js
+++ b/main.js
@@ -1492,6 +1492,37 @@ app.whenReady().then(() => {
     return { success: true };
   });
 
+  ipcMain.handle("settings:export-all", async () => {
+    const backup = {
+        version: 1,
+        settings: settingsStore.load(),
+        profiles: settingsStore.loadProfiles()
+    };
+    const dialogParent = settingsWindow && !settingsWindow.isDestroyed()
+      ? settingsWindow
+      : BrowserWindow.getFocusedWindow();
+    const result = await dialog.showSaveDialog(dialogParent, {
+      title: "Export Settings Backup",
+      defaultPath: "paraline-settings-backup.json",
+      filters: [
+        {
+          name: "JSON Files",
+          extensions: ["json"]
+        }
+      ]
+    });
+
+    if (result.canceled || !result.filePath) {
+      return { success: false };
+    }
+
+    require("fs").writeFileSync(
+      result.filePath,
+      JSON.stringify(backup, null, 2)
+    );
+
+    return { success: true };
+  });
   ipcMain.handle("theme-profiles:import", async () => {
     try {
       const dialogParent = settingsWindow && !settingsWindow.isDestroyed()
@@ -1545,6 +1576,69 @@ app.whenReady().then(() => {
       };
     } catch (error) {
       console.error("Failed to import theme profile:", error);
+      return { success: false, error: error.message };
+    }
+  });
+  
+  ipcMain.handle("settings:import-all", async () => {
+    try {
+      const dialogParent = settingsWindow && !settingsWindow.isDestroyed()
+        ? settingsWindow
+        : BrowserWindow.getFocusedWindow();
+
+      const result = await dialog.showOpenDialog(dialogParent, {
+        title: "Import Settings Backup",
+        filters: [
+          {
+            name: "JSON Files",
+            extensions: ["json"]
+          }
+        ],
+        properties: ["openFile"]
+      });
+
+      if (result.canceled || result.filePaths.length === 0) {
+        return { success: false };
+      }
+
+      const filePath = result.filePaths[0];
+
+      // Check file size (100KB limit to prevent DoS attacks)
+      const stats = fs.statSync(filePath);
+      const MAX_FILE_SIZE = 100 * 1024; // 100KB
+      if (stats.size > MAX_FILE_SIZE) {
+        return { success: false, error: "File too large. Maximum size is 100KB." };
+      }
+
+      const importedBackup = JSON.parse(
+          require("fs").readFileSync(filePath, "utf8")
+      );
+
+      if (!importedBackup || typeof importedBackup !== "object") {
+          return { success: false, error: "Invalid backup format" };
+      }
+
+      const cleanSettings = sanitizeSettings(
+          importedBackup.settings || {}
+      );
+
+      settingsStore.save(cleanSettings);
+
+      settingsStore.saveProfiles(
+          importedBackup.profiles || {}
+      );
+
+      visualizerSettings = cleanSettings;
+
+      sendVisualizerSettings();
+      refreshTrayMenu();
+
+      return {                                    
+        success: true,
+      };
+    }
+    catch (error) {
+      console.error("Failed to import settings backup:", error);
       return { success: false, error: error.message };
     }
   });

--- a/preload.js
+++ b/preload.js
@@ -98,6 +98,9 @@ contextBridge.exposeInMainWorld("paralineApp", {
   deleteThemeProfile: (profileName) =>
     ipcRenderer.invoke("theme-profiles:delete", profileName),
 
+  duplicateThemeProfile: (srcProfileName, destProfileName) =>
+    ipcRenderer.invoke("theme-profiles:duplicate", srcProfileName, destProfileName),
+
   exportThemeProfile: (profileName) =>
     ipcRenderer.invoke("theme-profiles:export", profileName),
 

--- a/settings.html
+++ b/settings.html
@@ -135,11 +135,6 @@
                     <div id="dynamic-theme-settings">
                         <!-- Populated dynamically by settings.js based on selected theme -->
                     </div>
-                        <div style="margin-top:16px;">
-                            <button id="btn-reset-theme" class="btn-secondary">
-                                Reset to Default
-                            </button>
-                    </div>
                 </div>
             </section>
 
@@ -471,6 +466,9 @@
 
                         <button id="btn-reset-theme-profile" class="btn-secondary">
                             Restore Defaults
+                        </button>
+                        <button id="btnDuplicateThemeProfile" class="btn-secondary">
+                            Duplicate
                         </button>
                     </div>
                 </div>

--- a/settings.js
+++ b/settings.js
@@ -340,6 +340,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const btnExportThemeProfile = document.getElementById('btn-export-theme-profile');
     const btnImportThemeProfile = document.getElementById('btn-import-theme-profile');
     const btnResetThemeProfile = document.getElementById('btn-reset-theme-profile');
+    const btnDuplicateThemeProfile = document.getElementById('btnDuplicateThemeProfile');
     
 
     let presets = {
@@ -560,6 +561,34 @@ refreshThemeProfiles();
 
             refreshThemeProfiles();
         });
+
+        if (btnDuplicateThemeProfile) {
+            btnDuplicateThemeProfile.addEventListener('click', async () => {
+                const selectedProfile = themeProfileSelector.value;
+
+                if (!selectedProfile) {
+                    alert("Please select a profile to duplicate.");
+                    return;
+                }
+
+                const newName = prompt("Enter a name for the duplicated profile:", `${selectedProfile} - Copy`);
+                if (newName === null) return; // User cancelled
+
+                const trimmedName = newName.trim();
+                if (trimmedName === "") {
+                    alert("Profile name cannot be empty.");
+                    return;
+                }
+
+                const res = await window.paralineApp.duplicateThemeProfile(selectedProfile, trimmedName);
+                if (res) {
+                    alert(`Profile duplicated successfully as "${trimmedName}"`);
+                    refreshThemeProfiles();
+                } else {
+                    alert("Failed to duplicate profile. Ensure the name is valid and not already in use.");
+                }
+            });
+        }
 
         btnExportThemeProfile.addEventListener('click', async () => {
             const selectedProfile = themeProfileSelector.value;


### PR DESCRIPTION
## Description

This PR adds support for exporting and importing complete Paraline configurations, allowing users to back up and restore their application settings easily.

### Features Added
- Export complete application settings to a JSON file
- Import previously exported settings backups
- Include theme profiles in the backup
- Validate imported backup structure before applying
- Sanitize imported settings using `sanitizeSettings()` before saving
- Apply restored settings immediately after import

### Testing
- Successfully exported settings backup to a JSON file
- Successfully imported exported backup file
- Verified theme profiles are included in the backup
- Verified imported settings are sanitized before being saved

### Screenshots
<img width="1112" height="814" alt="Screenshot (1628)" src="https://github.com/user-attachments/assets/082561d5-1bf6-4ed5-b909-e5c59f981273" />
<img width="1121" height="813" alt="Screenshot (1629)" src="https://github.com/user-attachments/assets/f43d409b-c2b9-4e28-a575-b098c9833687" />


Fixes #110

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Export all app settings and theme profiles to a backup file
  * Import app settings and theme profiles from a backup file with improved validation and error reporting
  * Duplicate an existing theme profile via the Theme Profiles UI

* **Bug Fixes / UX**
  * Removed the “Reset to Default” button from Theme Properties (streamlines theme controls)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->