### PR TITLE
fix(settings): guard loadProfiles against non-object JSON.parse results

### DIFF
--- a/settingsStore.js
+++ b/settingsStore.js
@@ -574,7 +574,13 @@ function createSettingsStore(userDataPath) {
       }
 
       const fileContent = fs.readFileSync(profilesPath, "utf8");
-      return JSON.parse(fileContent);
+      const parsed = JSON.parse(fileContent);
+      // JSON.parse can return null, arrays, or primitives. Guard against any
+      // non-plain-object result so callers always receive a key-value map.
+      if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+        return {};
+      }
+      return parsed;
     } catch (_error) {
       return {};
     }


### PR DESCRIPTION
## Summary

Closes #163

`loadProfiles()` returned the raw result of `JSON.parse()`. If `themeProfiles.json` contained `null`, a JSON array, or a primitive, callers performed property access on a non-object and threw an uncaught `TypeError` that prevented the settings window from loading.

## What Changed

`settingsStore.js`: After `JSON.parse`, check whether the result is a plain object (`!== null`, `typeof === "object"`, `!Array.isArray`). Any non-conforming result falls back to `{}`.

## Type of Change

- [x] Bug fix

*GSSoC '26 contribution*