### PR TITLE
fix(audio): cap audioBridge stdout buffer to prevent memory exhaustion

### DIFF
--- a/audioBridge.js
+++ b/audioBridge.js
@@ -55,6 +55,11 @@ function createAudioBridge(sendLevel, onStatusChange = () => {}) {
     let helperReady = false;
 
     let stdoutBuffer = "";
+    // Maximum bytes retained in the line buffer. If the helper emits a
+    // continuous stream with no newlines (crash dump, corrupt build), the
+    // buffer is discarded once it exceeds this limit to prevent OOM in the
+    // Electron main process.
+    const MAX_STDOUT_BUFFER_BYTES = 64 * 1024; // 64 KB
 
     helperProcess.stdout.on("data", (chunk) => {
       if (!helperReady) {
@@ -66,6 +71,12 @@ function createAudioBridge(sendLevel, onStatusChange = () => {}) {
   });
 }
       stdoutBuffer += chunk.toString();
+
+      if (stdoutBuffer.length > MAX_STDOUT_BUFFER_BYTES) {
+        console.warn("audioBridge: stdout buffer exceeded limit, discarding accumulated data.");
+        stdoutBuffer = "";
+        return;
+      }
 
       const lines = stdoutBuffer.split(/\r?\n/);
       stdoutBuffer = lines.pop() || "";


### PR DESCRIPTION
## Summary

Closes #164

`audioBridge.js` accumulated the C# helper's stdout output in `stdoutBuffer` with no upper bound. A misbehaving helper that emits a stream with no newlines causes the Electron main process to fill its heap until killed by the OS out-of-memory manager.

## What Changed

`audioBridge.js`: Added `MAX_STDOUT_BUFFER_BYTES = 64 * 1024`. If the buffer exceeds this limit after a chunk is appended, the accumulated data is discarded with a `console.warn` and the handler returns early. Normal JSON line messages are well under 1 KB so legitimate operation is unaffected.

## Type of Change

- [x] Bug fix (security / memory)

*GSSoC '26 contribution*