### PR TITLE
fix(settings): reject reserved preset names to prevent prototype pollution

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -330,6 +330,26 @@ document.addEventListener('DOMContentLoaded', () => {
     const btnResetThemeProfile = document.getElementById('btn-reset-theme-profile');
     
 
+    // Names that must not be used as object keys because they shadow prototype
+    // properties, which would allow an attacker to corrupt the JS execution
+    // context of the settings window via a crafted localStorage value.
+    const RESERVED_PRESET_NAMES = new Set([
+        "__proto__", "constructor", "prototype",
+        "toString", "valueOf", "hasOwnProperty",
+        "isPrototypeOf", "propertyIsEnumerable",
+        "toLocaleString", "__defineGetter__", "__defineSetter__",
+        "__lookupGetter__", "__lookupSetter__"
+    ]);
+
+    function isSafePresetName(name) {
+        return (
+            typeof name === "string" &&
+            name.length > 0 &&
+            name.length <= 64 &&
+            !RESERVED_PRESET_NAMES.has(name)
+        );
+    }
+
     let presets = {
         "Ocean Blue": ["#00f2fe", "#4facfe", "#8ee2ff"],
         "Sunset": ["#ff512f", "#f09819", "#ffb347"],
@@ -339,7 +359,19 @@ document.addEventListener('DOMContentLoaded', () => {
     // Load from local storage if available
     try {
         const savedPresets = localStorage.getItem('paraline_presets');
-        if (savedPresets) presets = JSON.parse(savedPresets);
+        if (savedPresets) {
+            const parsed = JSON.parse(savedPresets);
+            // Only accept plain objects with safe keys and array values.
+            if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
+                const sanitized = {};
+                for (const [key, val] of Object.entries(parsed)) {
+                    if (isSafePresetName(key) && Array.isArray(val) && val.length === 3) {
+                        sanitized[key] = val;
+                    }
+                }
+                presets = sanitized;
+            }
+        }
     } catch(e) {}
 
     function updatePresetDropdown() {
@@ -367,7 +399,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     savePresetBtn.addEventListener('click', () => {
         const presetName = presetNameInput.value.trim();
-        if (presetName !== "") {
+        if (presetName !== "" && isSafePresetName(presetName)) {
             presets[presetName] = [color1.value, color2.value, color3.value];
             updatePresetDropdown();
             presetSelector.value = presetName;


### PR DESCRIPTION
## Summary

Closes #165

The color preset save handler used the user-supplied name as an object key without any validation: `presets[presetName] = [...]`. Presets were also loaded from `localStorage` without filtering. A name of `__proto__`, `constructor`, or `toString` would modify the prototype or built-in properties of the `presets` object, corrupting the settings window's JavaScript execution context for the session.

## What Changed

`settings.js`:
- Added `RESERVED_PRESET_NAMES` Set containing `__proto__`, `constructor`, `prototype`, `toString`, and other built-in property names.
- Added `isSafePresetName(name)` that rejects empty strings, names longer than 64 characters, and reserved names.
- The save handler now calls `isSafePresetName` before writing.
- The `localStorage` load block rebuilds the presets object entry by entry, skipping any key that fails the safety check, so a crafted storage value cannot bypass the guard on future loads.

## Type of Change

- [x] Bug fix (security)

*GSSoC '26 contribution*