### PR TITLE
feat: make theme automation sunrise and sunset hours configurable

### DIFF
--- a/settings.css
+++ b/settings.css
@@ -1175,3 +1175,28 @@ input[type="range"]:active::-webkit-slider-thumb {
     border-radius: 2px;
 }
 
+/* Numeric input styling to match theme dropdowns */
+input[type="number"] {
+    background-color: var(--bg-input);
+    border: 1px solid var(--border-input);
+    border-radius: var(--radius-sm);
+    color: var(--text-main);
+    padding: 6px 10px;
+    font-family: inherit;
+    font-size: 0.88rem;
+    outline: none;
+    transition: all var(--duration-normal) var(--ease-smooth);
+    box-shadow: var(--shadow-input);
+}
+
+input[type="number"]:hover {
+    border-color: rgba(255, 255, 255, 0.12);
+    background-color: var(--bg-input-hover);
+}
+
+input[type="number"]:focus {
+    border-color: var(--border-focus);
+    box-shadow: var(--shadow-input), 0 0 0 3px rgba(0, 212, 255, 0.08);
+}
+
+

--- a/settings.html
+++ b/settings.html
@@ -556,8 +556,19 @@
                             <input type="number" id="intervalMinutes" min="1" max="120" value="30" style="width: 60px; margin-left: 10px;" />
                         </div>
 
+                        <div class="input-group" style="margin-top: 10px; display: flex; gap: 20px;">
+                            <div style="display: flex; align-items: center;">
+                                <label for="dayStartHourInput" style="margin-bottom: 0;">Day Start Hour:</label>
+                                <input type="number" id="dayStartHourInput" min="0" max="23" value="6" style="width: 60px; margin-left: 10px;" />
+                            </div>
+                            <div style="display: flex; align-items: center;">
+                                <label for="nightStartHourInput" style="margin-bottom: 0;">Night Start Hour:</label>
+                                <input type="number" id="nightStartHourInput" min="0" max="23" value="18" style="width: 60px; margin-left: 10px;" />
+                            </div>
+                        </div>
+
                         <div class="input-group" style="margin-top: 10px;">
-                            <label>Daytime Theme (6 AM - 6 PM):</label>
+                            <label id="dayThemeLabel">Daytime Theme (6 AM - 6 PM):</label>
                             <select class="styled-select" id="dayThemeSelect" style="margin-top: 5px;">
                                 <option value="ambientWave">Ambient Wave</option>
                                 <option value="reactiveBorder">Reactive Border</option>
@@ -573,7 +584,7 @@
                         </div>
 
                         <div class="input-group" style="margin-top: 10px;">
-                            <label>Nighttime Theme (6 PM - 6 AM):</label>
+                            <label id="nightThemeLabel">Nighttime Theme (6 PM - 6 AM):</label>
                             <select class="styled-select" id="nightThemeSelect" style="margin-top: 5px;">
                                 <option value="ambientWave">Ambient Wave</option>
                                 <option value="reactiveBorder">Reactive Border</option>

--- a/settings.js
+++ b/settings.js
@@ -201,6 +201,25 @@ document.addEventListener('DOMContentLoaded', () => {
     const intervalMinutes = document.getElementById('intervalMinutes');
     const dayThemeSelect = document.getElementById('dayThemeSelect');
     const nightThemeSelect = document.getElementById('nightThemeSelect');
+    const dayStartHourInput = document.getElementById('dayStartHourInput');
+    const nightStartHourInput = document.getElementById('nightStartHourInput');
+
+    function formatHour(hour) {
+        if (hour === 0) return '12 AM';
+        if (hour === 12) return '12 PM';
+        return hour > 12 ? `${hour - 12} PM` : `${hour} AM`;
+    }
+
+    function updateThemeLabels(dayStart, nightStart) {
+        const dayThemeLabel = document.getElementById('dayThemeLabel');
+        const nightThemeLabel = document.getElementById('nightThemeLabel');
+        if (dayThemeLabel) {
+            dayThemeLabel.textContent = `Daytime Theme (${formatHour(dayStart)} - ${formatHour(nightStart)}):`;
+        }
+        if (nightThemeLabel) {
+            nightThemeLabel.textContent = `Nighttime Theme (${formatHour(nightStart)} - ${formatHour(dayStart)}):`;
+        }
+    }
 
     function toggleAutoControls(isEnabled) {
         if (themeAutoControls) {
@@ -243,6 +262,32 @@ document.addEventListener('DOMContentLoaded', () => {
     if (nightThemeSelect) {
         nightThemeSelect.addEventListener('change', (e) => {
             updateAutomationSetting({ nightTheme: e.target.value });
+        });
+    }
+
+    if (dayStartHourInput) {
+        dayStartHourInput.addEventListener('change', (e) => {
+            let val = parseInt(e.target.value, 10);
+            if (isNaN(val) || val < 0 || val > 23) {
+                val = 6;
+                dayStartHourInput.value = val;
+            }
+            updateAutomationSetting({ dayStartHour: val });
+            const nightStart = nightStartHourInput ? parseInt(nightStartHourInput.value, 10) : 18;
+            updateThemeLabels(val, isNaN(nightStart) ? 18 : nightStart);
+        });
+    }
+
+    if (nightStartHourInput) {
+        nightStartHourInput.addEventListener('change', (e) => {
+            let val = parseInt(e.target.value, 10);
+            if (isNaN(val) || val < 0 || val > 23) {
+                val = 18;
+                nightStartHourInput.value = val;
+            }
+            updateAutomationSetting({ nightStartHour: val });
+            const dayStart = dayStartHourInput ? parseInt(dayStartHourInput.value, 10) : 6;
+            updateThemeLabels(isNaN(dayStart) ? 6 : dayStart, val);
         });
     }
 
@@ -701,6 +746,15 @@ refreshThemeProfiles();
                 if (nightThemeSelect) {
                     nightThemeSelect.value = automation.nightTheme || "reactiveBorder";
                 }
+                const dayStart = automation.dayStartHour !== undefined ? automation.dayStartHour : 6;
+                const nightStart = automation.nightStartHour !== undefined ? automation.nightStartHour : 18;
+                if (dayStartHourInput) {
+                    dayStartHourInput.value = dayStart;
+                }
+                if (nightStartHourInput) {
+                    nightStartHourInput.value = nightStart;
+                }
+                updateThemeLabels(dayStart, nightStart);
             }
             
             // set custom variables into UI if they exist globally or on the active theme
@@ -747,6 +801,15 @@ refreshThemeProfiles();
                 if (nightThemeSelect && automation.nightTheme !== undefined) {
                     nightThemeSelect.value = automation.nightTheme;
                 }
+                if (dayStartHourInput && automation.dayStartHour !== undefined) {
+                    dayStartHourInput.value = automation.dayStartHour;
+                }
+                if (nightStartHourInput && automation.nightStartHour !== undefined) {
+                    nightStartHourInput.value = automation.nightStartHour;
+                }
+                const dayStart = automation.dayStartHour !== undefined ? automation.dayStartHour : (cachedSettings.themeAutomation?.dayStartHour ?? 6);
+                const nightStart = automation.nightStartHour !== undefined ? automation.nightStartHour : (cachedSettings.themeAutomation?.nightStartHour ?? 18);
+                updateThemeLabels(dayStart, nightStart);
             }
 
             if (nextSettings.paused !== undefined) {

--- a/settingsStore.js
+++ b/settingsStore.js
@@ -11,7 +11,9 @@ const DEFAULT_SETTINGS = Object.freeze({
     checkIntervalMinutes: 30, 
     mode: "dayNight",         
     dayTheme: "ambientWave", 
-    nightTheme: "reactiveBorder"
+    nightTheme: "reactiveBorder",
+    dayStartHour: 6,
+    nightStartHour: 18
   }),
   performanceMode: "balanced",
   fpsLimit: "default",
@@ -248,6 +250,20 @@ function legacySensitivityToLevel(value) {
 }
 
 function sanitizeThemeAutomation(input = {}) {
+  let dayStart = typeof input.dayStartHour === "number"
+    ? input.dayStartHour
+    : (input.dayStartHour !== undefined ? parseInt(input.dayStartHour, 10) : DEFAULT_SETTINGS.themeAutomation.dayStartHour);
+  if (isNaN(dayStart) || dayStart < 0 || dayStart > 23) {
+    dayStart = DEFAULT_SETTINGS.themeAutomation.dayStartHour;
+  }
+
+  let nightStart = typeof input.nightStartHour === "number"
+    ? input.nightStartHour
+    : (input.nightStartHour !== undefined ? parseInt(input.nightStartHour, 10) : DEFAULT_SETTINGS.themeAutomation.nightStartHour);
+  if (isNaN(nightStart) || nightStart < 0 || nightStart > 23) {
+    nightStart = DEFAULT_SETTINGS.themeAutomation.nightStartHour;
+  }
+
   return {
     enabled: typeof input.enabled === "boolean" ? input.enabled : DEFAULT_SETTINGS.themeAutomation.enabled,
     checkIntervalMinutes: typeof input.checkIntervalMinutes === "number"
@@ -255,7 +271,9 @@ function sanitizeThemeAutomation(input = {}) {
       : DEFAULT_SETTINGS.themeAutomation.checkIntervalMinutes,
     mode: typeof input.mode === "string" ? input.mode : DEFAULT_SETTINGS.themeAutomation.mode,
     dayTheme: pick(input.dayTheme, VALID_MAIN_THEMES, DEFAULT_SETTINGS.themeAutomation.dayTheme),
-    nightTheme: pick(input.nightTheme, VALID_MAIN_THEMES, DEFAULT_SETTINGS.themeAutomation.nightTheme)
+    nightTheme: pick(input.nightTheme, VALID_MAIN_THEMES, DEFAULT_SETTINGS.themeAutomation.nightTheme),
+    dayStartHour: dayStart,
+    nightStartHour: nightStart
   };
 }
 

--- a/themeAgent.js
+++ b/themeAgent.js
@@ -47,7 +47,16 @@ class ThemeAgent {
 
     try {
       const currentHour = new Date().getHours();
-      const isDaytime = currentHour >= 6 && currentHour < 18; // 6 AM to 6 PM
+      const dayStartHour = config.dayStartHour !== undefined ? config.dayStartHour : 6;
+      const nightStartHour = config.nightStartHour !== undefined ? config.nightStartHour : 18;
+
+      let isDaytime;
+      if (dayStartHour < nightStartHour) {
+        isDaytime = currentHour >= dayStartHour && currentHour < nightStartHour;
+      } else {
+        // Wraps around midnight (e.g. day starts at 20 (8 PM) and ends at 6 (6 AM))
+        isDaytime = currentHour >= dayStartHour || currentHour < nightStartHour;
+      }
       const targetTheme = isDaytime ? config.dayTheme : config.nightTheme;
 
       const storeData = this.settingsStore.load() || {};


### PR DESCRIPTION
### Description
This PR resolves the issue where theme automation transition boundaries were hardcoded to 6 AM (daytime) and 6 PM (nighttime). It introduces two configurable settings (`dayStartHour` and `nightStartHour`) to the Theme Automation settings, allowing users to customize their transition schedule.

### Changes
1. **Backend & Settings Validation (`settingsStore.js`)**:
   - Added `dayStartHour` (default: 6) and `nightStartHour` (default: 18) defaults to the schema.
   - Updated `sanitizeThemeAutomation` to validate that these inputs are valid integers in the `[0, 23]` range.
2. **Theme Automation Logic (`themeAgent.js`)**:
   - Replaced hardcoded bounds with dynamic evaluation using the user-defined hours.
   - Supported wrap-around overnight schedules (e.g. when day start hour is greater than night start hour, such as 8 PM to 6 AM).
3. **Settings UI (`settings.html`, `settings.js`, `settings.css`)**:
   - Exposed numeric input elements in the settings panel for customizing hours.
   - Implemented dynamic label updating to show active times in 12-hour format (e.g., `Daytime Theme (7 AM - 7 PM)`).
   - Styled the input fields using existing CSS variables to seamlessly match the application's premium UI design.

### Verification
- Tested and verified settings sanitization (invalid range fallback & string conversion).
- Verified the correct evaluation of day vs. night themes for both standard and overnight wrap-around configurations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Customize day and night theme automation start hours. Users can now set preferred times for theme switching instead of the fixed 6 AM and 6 PM defaults.
  * Theme labels dynamically update to reflect selected hour ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->