### PR TITLE
fix: add Aurora Drift to theme automation day/night dropdowns

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -578,6 +578,7 @@
                                 <option value="snowBubbleParticles">Snow Particles</option>
                                 <option value="edgeCrystals">Edge Crystals</option>
                                 <option value="sideBraids">Side Braids</option>
+                                <option value="auroraDrift">Aurora Drift</option>
                             </select>
                         </div>
 
@@ -594,6 +595,7 @@
                                 <option value="snowBubbleParticles">Snow Particles</option>
                                 <option value="edgeCrystals">Edge Crystals</option>
                                 <option value="sideBraids">Side Braids</option>
+                                <option value="auroraDrift">Aurora Drift</option>
                             </select>
                         </div>
                     </div>


### PR DESCRIPTION
## Problem

`auroraDrift` is a fully valid theme — it is listed in `VALID_MAIN_THEMES`
and appears in the main theme selector. However, it was missing from both
the **Daytime Theme** (`#dayThemeSelect`) and **Nighttime Theme**
(`#nightThemeSelect`) dropdowns in the Tweaks → Time-Based Theme Switching
section of `settings.html`.

This meant users could not schedule Aurora Drift via automation, creating
an inconsistency with the rest of the UI.

## Fix

Added `<option value="auroraDrift">Aurora Drift</option>` to both
`#dayThemeSelect` and `#nightThemeSelect` dropdowns, making them
consistent with the full theme list available in the main selector.

## Files Changed

- `settings.html` — added Aurora Drift option to both automation dropdowns (lines ~581, ~598)

## Testing

1. Open Settings → Tweaks tab
2. Enable "Time-Based Theme Switching"
3. Verify **Aurora Drift** now appears in both the Daytime and Nighttime theme dropdowns
