### PR TITLE
fix: use issues.createComment for PR auto-reply workflow

### DIFF
--- a/.github/workflows/auto-reply.yml
+++ b/.github/workflows/auto-reply.yml
@@ -75,9 +75,9 @@ jobs:
               'Appreciate the effort you put into improving Paraline 👍'
             ].join('\n');
 
-            await github.rest.pulls.createComment({
+            await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
+              issue_number: context.payload.pull_request.number,
               body
             });


### PR DESCRIPTION
## Problem

The `pr-reply` job in `.github/workflows/auto-reply.yml` was failing
because it called `github.rest.pulls.createComment()`, which is the
API for creating **review comments** (line-level comments tied to a
diff). This method requires additional parameters (`commit_id`, `path`,
`position`) that were not supplied, causing the job to error out.

## Fix

Replaced the incorrect API call on line 78 with the correct one:

```diff
- await github.rest.pulls.createComment({
-   owner: context.repo.owner,
-   repo: context.repo.repo,
-   pull_number: context.payload.pull_request.number,
-   body
- });
+ await github.rest.issues.createComment({
+   owner: context.repo.owner,
+   repo: context.repo.repo,
+   issue_number: context.payload.pull_request.number,
+   body
+ });
