### PR TITLE
Fix theme profile duplication flow

### DIFF
--- a/main.js
+++ b/main.js
@@ -428,6 +428,7 @@ function resetAllSettings() {
 // Using these as keys on a plain object pollutes Object.prototype and affects
 // every plain object created in the same process for the rest of its lifetime.
 const RESERVED_PROFILE_NAMES = new Set(["__proto__", "constructor", "prototype"]);
+const MAX_PROFILE_NAME_LENGTH = 64;
 
 // Allowlist pattern: profile names may only contain letters, digits,
 // spaces, hyphens, underscores, and parentheses (max 64 chars).
@@ -437,6 +438,36 @@ function isValidProfileName(name) {
   if (typeof name !== "string" || name.trim() === "") return false;
   if (RESERVED_PROFILE_NAMES.has(name)) return false;
   return SAFE_PROFILE_NAME_RE.test(name);
+}
+
+function hasThemeProfile(profiles, profileName) {
+  return Object.prototype.hasOwnProperty.call(profiles, profileName);
+}
+
+function createDuplicateProfileName(profileName, profiles) {
+  let counter = 1;
+
+  while (true) {
+    const suffix = counter === 1 ? " (Copy)" : ` (Copy ${counter})`;
+    const maxBaseLength = MAX_PROFILE_NAME_LENGTH - suffix.length;
+
+    if (maxBaseLength < 1) {
+      return null;
+    }
+
+    const baseName = profileName.slice(0, maxBaseLength).trimEnd();
+    const copyName = `${baseName}${suffix}`;
+
+    if (!isValidProfileName(copyName)) {
+      return null;
+    }
+
+    if (!hasThemeProfile(profiles, copyName)) {
+      return copyName;
+    }
+
+    counter += 1;
+  }
 }
 
 function saveThemeProfile(profileName) {
@@ -453,35 +484,43 @@ function saveThemeProfile(profileName) {
 }
 
 function duplicateThemeProfile(profileName) {
-    const profiles = settingsStore.loadProfiles();
-
-    if (!profiles[profileName]) {
-        return {
-            success: false,
-            error: "Profile not found"
-        };
-    }
-
-    let newName = `${profileName} (Copy)`;
-    let counter = 2;
-
-    while (profiles[newName]) {
-        newName = `${profileName} (Copy ${counter})`;
-        counter++;
-    }
-
-    const duplicatedProfile = JSON.parse(
-        JSON.stringify(profiles[profileName])
-    );
-
-    profiles[newName] = sanitizeSettings(duplicatedProfile);
-
-    settingsStore.saveProfiles(profiles);
-
+  if (!isValidProfileName(profileName)) {
     return {
-        success: true,
-        profileName: newName
+      success: false,
+      error: "Invalid profile name"
     };
+  }
+
+  const profiles = settingsStore.loadProfiles();
+
+  if (!hasThemeProfile(profiles, profileName)) {
+    return {
+      success: false,
+      error: "Profile not found"
+    };
+  }
+
+  const newName = createDuplicateProfileName(profileName, profiles);
+
+  if (!newName) {
+    return {
+      success: false,
+      error: "Could not create a valid copy name"
+    };
+  }
+
+  const duplicatedProfile = JSON.parse(
+    JSON.stringify(profiles[profileName])
+  );
+
+  profiles[newName] = sanitizeSettings(duplicatedProfile);
+
+  settingsStore.saveProfiles(profiles);
+
+  return {
+    success: true,
+    profileName: newName
+  };
 }
 
 function loadThemeProfile(profileName) {
@@ -512,23 +551,6 @@ function deleteThemeProfile(profileName) {
 
   settingsStore.saveProfiles(profiles);
 
-  return profiles;
-}
-
-function duplicateThemeProfile(srcName, destName) {
-  if (
-    typeof srcName !== "string" || srcName.trim() === "" ||
-    typeof destName !== "string" || destName.trim() === "" ||
-    destName === "__proto__" || destName === "constructor" || destName === "prototype"
-  ) {
-    return null;
-  }
-  const profiles = settingsStore.loadProfiles();
-  if (!profiles[srcName]) {
-    return null;
-  }
-  profiles[destName] = JSON.parse(JSON.stringify(profiles[srcName]));
-  settingsStore.saveProfiles(profiles);
   return profiles;
 }
 

--- a/preload.js
+++ b/preload.js
@@ -98,8 +98,8 @@ contextBridge.exposeInMainWorld("paralineApp", {
   deleteThemeProfile: (profileName) =>
     ipcRenderer.invoke("theme-profiles:delete", profileName),
 
-  duplicateThemeProfile: (srcProfileName, destProfileName) =>
-    ipcRenderer.invoke("theme-profiles:duplicate", srcProfileName, destProfileName),
+  duplicateThemeProfile: (profileName) =>
+    ipcRenderer.invoke("theme-profiles:duplicate", profileName),
 
   exportThemeProfile: (profileName) =>
     ipcRenderer.invoke("theme-profiles:export", profileName),
@@ -110,11 +110,6 @@ contextBridge.exposeInMainWorld("paralineApp", {
   resetThemeSettings: () =>
     ipcRenderer.invoke("theme-profiles:reset"),
 
-  duplicateThemeProfile: (profileName) =>
-    ipcRenderer.invoke(
-      'theme-profiles:duplicate',
-      profileName
-    ),
   resetActiveThemeSettings: () =>
     ipcRenderer.invoke("theme-profiles:reset-current")
 });

--- a/settings.js
+++ b/settings.js
@@ -506,7 +506,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     updatePresetDropdown();
-    async function refreshThemeProfiles() {
+    async function refreshThemeProfiles(selectedProfileName = "") {
     if (!window.paralineApp) return;
 
     const profiles = await window.paralineApp.getThemeProfiles();
@@ -522,6 +522,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
         themeProfileSelector.appendChild(option);
     });
+
+    if (selectedProfileName && Object.prototype.hasOwnProperty.call(profiles, selectedProfileName)) {
+        themeProfileSelector.value = selectedProfileName;
+    }
 }
 
 refreshThemeProfiles();
@@ -719,7 +723,7 @@ refreshThemeProfiles();
                 }
 
                 alert(`Profile duplicated as "${result.profileName}"`);
-                refreshThemeProfiles();
+                await refreshThemeProfiles(result.profileName);
             } catch (error) {
                 alert("Failed to duplicate profile");
                 console.error(error);


### PR DESCRIPTION
## Summary
- Remove the conflicting duplicate theme profile implementation in `main.js`.
- Expose a single `duplicateThemeProfile(profileName)` preload API that matches the settings UI call site.
- Keep duplicated profiles sanitized and give each copy a unique generated name.

## Details
The duplication flow had two `duplicateThemeProfile` declarations in `main.js`. JavaScript hoisting made the later `(srcName, destName)` implementation override the intended one-argument implementation, so the settings UI could receive `null` instead of the `{ success, profileName }` shape it expects.

This unifies the flow around one main-process API. It validates the source profile name, rejects reserved keys through the existing profile-name guard, checks profile existence with own-property lookup, generates names like `Profile (Copy)` and `Profile (Copy 2)`, sanitizes the duplicated settings before saving, and returns a consistent success or error object.

The settings UI now refreshes the dropdown after duplication and selects the newly created copy so users can see the result immediately.

## Validation
- `node --check main.js`
- `node --check preload.js`
- `node --check settings.js`
- `git diff --check`
- `npm run validate:helper`

Closes #200