### PR TITLE
fix: dynamically resolve app version from visualizer settings

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -822,6 +822,17 @@ refreshThemeProfiles();
             updatePauseButtonState(settings.paused);
             updateHideButtonState(settings.hidden);
             
+            if (settings.version) {
+                const versionBadge = document.querySelector('.sidebar-version');
+                if (versionBadge) {
+                    versionBadge.textContent = `v${settings.version}`;
+                }
+                const aboutVersionBadge = document.querySelector('.about-version-badge');
+                if (aboutVersionBadge) {
+                    aboutVersionBadge.textContent = `v${settings.version} — Stable Release`;
+                }
+            }
+            
             if (settings.selectedTheme) {
                 themeSelector.value = settings.selectedTheme;
                 syncThemeUI(settings.selectedTheme);
@@ -922,6 +933,17 @@ refreshThemeProfiles();
         // Realtime dynamic synchronization when toggled from the tray context menu
         window.visualizerSettings.onChange((nextSettings) => {
             Object.assign(cachedSettings, nextSettings);
+
+            if (nextSettings.version) {
+                const versionBadge = document.querySelector('.sidebar-version');
+                if (versionBadge) {
+                    versionBadge.textContent = `v${nextSettings.version}`;
+                }
+                const aboutVersionBadge = document.querySelector('.about-version-badge');
+                if (aboutVersionBadge) {
+                    aboutVersionBadge.textContent = `v${nextSettings.version} — Stable Release`;
+                }
+            }
 
             if (nextSettings.selectedTheme !== undefined) {
                 if (themeSelector.value !== nextSettings.selectedTheme) {


### PR DESCRIPTION
### Description

This PR resolves an issue where the app version badge shown in the settings window (both in the sidebar and the "About" tab) was hardcoded to `v2.0.0`. 

The main process already computes the dynamic app version using `app.getVersion()` and exposes it via `visualizerSettings` settings payload (the `version` field). This fix updates the settings renderer to dynamically apply this version to the UI upon initial load and on settings update events.

Closes issue #203 

### Changes

- **Modified** [settings.js](file:///c:/Users/KIRTAN/Downloads/Paraline/settings.js):
  - Fetches the dynamic `version` from `visualizerSettings.get()` and updates the text content of the `.sidebar-version` and `.about-version-badge` elements on initialization.
  - Updates these version badges inside the `visualizerSettings.onChange` listener to handle any settings-update events dynamically.

### Verification Steps

1. Bump `version` in `package.json` to a test value (e.g., `2.1.0`).
2. Run the application (`npm run dev`).
3. Open the Settings window.
4. Verify that the version badge in the sidebar and the "About" section correctly displays the bumped version (e.g., `v2.1.0` and `v2.1.0 — Stable Release`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Version number and release status now display in the settings UI sidebar and about section, providing clarity on your current application version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->