### PR TITLE
feat: add global keyboard shortcuts configuration and system integration

### DIFF
--- a/main.js
+++ b/main.js
@@ -319,9 +319,12 @@ function registerGlobalShortcuts() {
   const pauseAcc = formatAccelerator(shortcuts.togglePause);
   if (pauseAcc) {
     try {
-      globalShortcut.register(pauseAcc, () => {
+      const registered = globalShortcut.register(pauseAcc, () => {
         togglePaused();
       });
+      if (!registered) {
+        console.error(`Failed to register global shortcut for pause/resume: ${pauseAcc} (possibly registered by another application)`);
+      }
     } catch (err) {
       console.error(`Failed to register global shortcut for pause/resume: ${pauseAcc}`, err);
     }
@@ -330,9 +333,12 @@ function registerGlobalShortcuts() {
   const hideAcc = formatAccelerator(shortcuts.toggleHide);
   if (hideAcc) {
     try {
-      globalShortcut.register(hideAcc, () => {
+      const registered = globalShortcut.register(hideAcc, () => {
         toggleHidden();
       });
+      if (!registered) {
+        console.error(`Failed to register global shortcut for hide/show: ${hideAcc} (possibly registered by another application)`);
+      }
     } catch (err) {
       console.error(`Failed to register global shortcut for hide/show: ${hideAcc}`, err);
     }
@@ -341,9 +347,12 @@ function registerGlobalShortcuts() {
   const cycleAcc = formatAccelerator(shortcuts.cycleTheme);
   if (cycleAcc) {
     try {
-      globalShortcut.register(cycleAcc, () => {
+      const registered = globalShortcut.register(cycleAcc, () => {
         cycleTheme();
       });
+      if (!registered) {
+        console.error(`Failed to register global shortcut for cycling theme: ${cycleAcc} (possibly registered by another application)`);
+      }
     } catch (err) {
       console.error(`Failed to register global shortcut for cycling theme: ${cycleAcc}`, err);
     }
@@ -484,6 +493,7 @@ function resetCurrentThemeSettings() {
 function resetAllSettings() {
   visualizerSettings = settingsStore.save(createDefaultSettings());
   isPaused = false;
+  registerGlobalShortcuts();
   sendVisualizerSettings();
   refreshTrayMenu();
 }
@@ -559,6 +569,7 @@ function loadThemeProfile(profileName) {
 
   visualizerSettings = settingsStore.save(profiles[profileName]);
 
+  registerGlobalShortcuts();
   sendVisualizerSettings();
   refreshTrayMenu();
 
@@ -1820,6 +1831,7 @@ app.whenReady().then(() => {
           themeAgent.start();
       }
 
+      registerGlobalShortcuts();
       sendVisualizerSettings();
       refreshTrayMenu();
 

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain, Menu, Tray, nativeImage, screen, shell, dialog, nativeTheme, systemPreferences, powerMonitor } = require("electron");
+const { app, BrowserWindow, ipcMain, Menu, Tray, nativeImage, screen, shell, dialog, nativeTheme, systemPreferences, powerMonitor, globalShortcut } = require("electron");
 const path = require("path");
 const fs = require("fs");
 const { createAudioBridge } = require("./audioBridge");
@@ -267,6 +267,9 @@ function updateSettings(nextSettings) {
   if (nextSettings.themeAutomation !== undefined && themeAgent) {
     themeAgent.start();
   }
+  if (nextSettings.shortcuts !== undefined) {
+    registerGlobalShortcuts();
+  }
 
   sendVisualizerSettings();
   refreshTrayMenu();
@@ -291,6 +294,60 @@ function reloadVisualizer() {
 
   stopSimulatedAudioFallback();
   overlayWindow.webContents.reloadIgnoringCache();
+}
+
+function cycleTheme() {
+  const themes = ["ambientWave", "auroraDrift", "reactiveBorder", "flowBorder", "sideBars", "flatRipples", "dotParticles", "rippleFlow", "snowBubbleParticles", "edgeCrystals", "sideBraids"];
+  const currentTheme = visualizerSettings.selectedTheme;
+  const currentIndex = themes.indexOf(currentTheme);
+  const nextIndex = (currentIndex + 1) % themes.length;
+  const nextTheme = themes[nextIndex];
+  updateSettings({ selectedTheme: nextTheme });
+}
+
+function registerGlobalShortcuts() {
+  globalShortcut.unregisterAll();
+
+  const shortcuts = visualizerSettings.shortcuts;
+  if (!shortcuts) return;
+
+  const formatAccelerator = (uiShortcut) => {
+    if (!uiShortcut || uiShortcut === "None") return null;
+    return uiShortcut;
+  };
+
+  const pauseAcc = formatAccelerator(shortcuts.togglePause);
+  if (pauseAcc) {
+    try {
+      globalShortcut.register(pauseAcc, () => {
+        togglePaused();
+      });
+    } catch (err) {
+      console.error(`Failed to register global shortcut for pause/resume: ${pauseAcc}`, err);
+    }
+  }
+
+  const hideAcc = formatAccelerator(shortcuts.toggleHide);
+  if (hideAcc) {
+    try {
+      globalShortcut.register(hideAcc, () => {
+        toggleHidden();
+      });
+    } catch (err) {
+      console.error(`Failed to register global shortcut for hide/show: ${hideAcc}`, err);
+    }
+  }
+
+  const cycleAcc = formatAccelerator(shortcuts.cycleTheme);
+  if (cycleAcc) {
+    try {
+      globalShortcut.register(cycleAcc, () => {
+        cycleTheme();
+      });
+    } catch (err) {
+      console.error(`Failed to register global shortcut for cycling theme: ${cycleAcc}`, err);
+    }
+  }
 }
 
 // --- Focus Mode polling ---
@@ -1447,6 +1504,7 @@ app.whenReady().then(() => {
   settingsStore = createSettingsStore(app.getPath("userData"));
   visualizerSettings = settingsStore.save(settingsStore.load());
   applyStartupSettings(visualizerSettings.launchOnStartup);
+  registerGlobalShortcuts();
 
   nativeTheme.on("updated", () => {
     sendVisualizerSettings();
@@ -1832,6 +1890,7 @@ app.on("before-quit", () => {
 
 app.on("will-quit", () => {
   stopSimulatedAudioFallback();
+  globalShortcut.unregisterAll();
 });
 
 app.on("window-all-closed", () => {

--- a/settings.html
+++ b/settings.html
@@ -482,6 +482,26 @@
                 </header>
 
                 <div class="settings-group">
+                    <h3>Global Hotkeys</h3>
+                    <p class="setting-desc">Control Paraline globally even when it is minimized or running in the background. Click inside a field and press a key combination to customize (e.g. <code>Ctrl+Alt+P</code>). Press <code>Backspace</code> or <code>Escape</code> to clear/disable.</p>
+                    
+                    <div style="display: flex; flex-direction: column; gap: 14px; margin-top: 14px; max-width: 450px;">
+                        <div style="display: flex; justify-content: space-between; align-items: center;">
+                            <label for="hotkey-toggle-pause" style="margin-bottom: 0; font-size: 14px; color: #e2e8f0; font-weight: 500;">Pause / Resume Visualizer:</label>
+                            <input type="text" id="hotkey-toggle-pause" class="styled-select" style="width: 180px; text-align: center; font-family: monospace; font-size: 13px; font-weight: 600; background: rgba(0, 0, 0, 0.2);" readonly placeholder="Press keys..." />
+                        </div>
+                        <div style="display: flex; justify-content: space-between; align-items: center;">
+                            <label for="hotkey-toggle-hide" style="margin-bottom: 0; font-size: 14px; color: #e2e8f0; font-weight: 500;">Hide / Show Visualizer:</label>
+                            <input type="text" id="hotkey-toggle-hide" class="styled-select" style="width: 180px; text-align: center; font-family: monospace; font-size: 13px; font-weight: 600; background: rgba(0, 0, 0, 0.2);" readonly placeholder="Press keys..." />
+                        </div>
+                        <div style="display: flex; justify-content: space-between; align-items: center;">
+                            <label for="hotkey-cycle-theme" style="margin-bottom: 0; font-size: 14px; color: #e2e8f0; font-weight: 500;">Cycle Active Theme:</label>
+                            <input type="text" id="hotkey-cycle-theme" class="styled-select" style="width: 180px; text-align: center; font-family: monospace; font-size: 13px; font-weight: 600; background: rgba(0, 0, 0, 0.2);" readonly placeholder="Press keys..." />
+                        </div>
+                    </div>
+                </div>
+
+                <div class="settings-group">
                     <h3>Performance Mode</h3>
                     <p class="setting-desc">Balance visual quality with system performance. Lower modes reduce GPU usage.</p>
                     <div class="input-group" style="margin-top: 10px;">

--- a/settings.js
+++ b/settings.js
@@ -554,9 +554,21 @@ refreshThemeProfiles();
             if (e.altKey) parts.push('Alt');
             if (e.shiftKey) parts.push('Shift');
 
+            const domToElectronKeyMap = {
+                'ArrowUp': 'Up',
+                'ArrowDown': 'Down',
+                'ArrowLeft': 'Left',
+                'ArrowRight': 'Right',
+                '+': 'Plus',
+                ' ': 'Space'
+            };
+
             let keyName = e.key;
-            if (keyName === ' ') keyName = 'Space';
-            if (keyName.length === 1) keyName = keyName.toUpperCase();
+            if (domToElectronKeyMap[keyName]) {
+                keyName = domToElectronKeyMap[keyName];
+            } else if (keyName.length === 1) {
+                keyName = keyName.toUpperCase();
+            }
 
             // Guard: Require at least one modifier key or a function key
             if (parts.length === 0 && !/^F[1-9][0-2]?$/.test(keyName)) {

--- a/settings.js
+++ b/settings.js
@@ -527,6 +527,63 @@ document.addEventListener('DOMContentLoaded', () => {
 refreshThemeProfiles();
 
     // ----------------------------------------
+    // HOTKEY RECORDERS
+    // ----------------------------------------
+    function setupHotkeyRecorder(inputId, settingKey) {
+        const input = document.getElementById(inputId);
+        if (!input) return;
+
+        input.addEventListener('keydown', (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+
+            // Clear hotkey if Backspace or Escape is pressed
+            if (e.key === 'Backspace' || e.key === 'Escape') {
+                input.value = 'None';
+                dispatchHotkeyUpdate(settingKey, 'None');
+                return;
+            }
+
+            // Ignore pure modifier presses
+            if (['Control', 'Alt', 'Shift', 'Meta'].includes(e.key)) {
+                return;
+            }
+
+            const parts = [];
+            if (e.ctrlKey) parts.push('Ctrl');
+            if (e.altKey) parts.push('Alt');
+            if (e.shiftKey) parts.push('Shift');
+
+            let keyName = e.key;
+            if (keyName === ' ') keyName = 'Space';
+            if (keyName.length === 1) keyName = keyName.toUpperCase();
+
+            // Guard: Require at least one modifier key or a function key
+            if (parts.length === 0 && !/^F[1-9][0-2]?$/.test(keyName)) {
+                return;
+            }
+
+            parts.push(keyName);
+            const shortcutStr = parts.join('+');
+            input.value = shortcutStr;
+            dispatchHotkeyUpdate(settingKey, shortcutStr);
+        });
+    }
+
+    function dispatchHotkeyUpdate(settingKey, value) {
+        if (!window.visualizerSettings) return;
+        if (!cachedSettings.shortcuts) cachedSettings.shortcuts = {};
+        cachedSettings.shortcuts[settingKey] = value;
+        window.visualizerSettings.update({
+            shortcuts: cachedSettings.shortcuts
+        });
+    }
+
+    setupHotkeyRecorder('hotkey-toggle-pause', 'togglePause');
+    setupHotkeyRecorder('hotkey-toggle-hide', 'toggleHide');
+    setupHotkeyRecorder('hotkey-cycle-theme', 'cycleTheme');
+
+    // ----------------------------------------
     // SLIDER UPDATES
     // ----------------------------------------
     const thicknessSlider = document.getElementById('customThickness');
@@ -851,6 +908,16 @@ refreshThemeProfiles();
                 }
             }
 
+            // Load global hotkeys
+            if (settings.shortcuts) {
+                const pauseInput = document.getElementById('hotkey-toggle-pause');
+                const hideInput = document.getElementById('hotkey-toggle-hide');
+                const cycleInput = document.getElementById('hotkey-cycle-theme');
+                if (pauseInput) pauseInput.value = settings.shortcuts.togglePause || 'None';
+                if (hideInput) hideInput.value = settings.shortcuts.toggleHide || 'None';
+                if (cycleInput) cycleInput.value = settings.shortcuts.cycleTheme || 'None';
+            }
+
             // Load theme automation settings
             if (settings.themeAutomation) {
                 const automation = settings.themeAutomation;
@@ -930,6 +997,22 @@ refreshThemeProfiles();
                 }
             }
             
+            // Sync global hotkeys
+            if (nextSettings.shortcuts) {
+                const pauseInput = document.getElementById('hotkey-toggle-pause');
+                const hideInput = document.getElementById('hotkey-toggle-hide');
+                const cycleInput = document.getElementById('hotkey-cycle-theme');
+                if (pauseInput && nextSettings.shortcuts.togglePause !== undefined) {
+                    pauseInput.value = nextSettings.shortcuts.togglePause || 'None';
+                }
+                if (hideInput && nextSettings.shortcuts.toggleHide !== undefined) {
+                    hideInput.value = nextSettings.shortcuts.toggleHide || 'None';
+                }
+                if (cycleInput && nextSettings.shortcuts.cycleTheme !== undefined) {
+                    cycleInput.value = nextSettings.shortcuts.cycleTheme || 'None';
+                }
+            }
+
             // Sync theme automation properties if updated from outside
             if (nextSettings.themeAutomation) {
                 const automation = nextSettings.themeAutomation;

--- a/settingsStore.js
+++ b/settingsStore.js
@@ -30,6 +30,11 @@ const DEFAULT_SETTINGS = Object.freeze({
     dayStartHour: 6,
     nightStartHour: 18
   }),
+  shortcuts: Object.freeze({
+    togglePause: "Ctrl+Alt+P",
+    toggleHide: "Ctrl+Alt+H",
+    cycleTheme: "Ctrl+Alt+T"
+  }),
   performanceMode: "balanced",
   fpsLimit: "default",
   ambientWave: Object.freeze({
@@ -211,6 +216,7 @@ function createDefaultSettings() {
     selectedTheme: DEFAULT_SETTINGS.selectedTheme,
     colorMode: DEFAULT_SETTINGS.colorMode,
     themeAutomation: { ...DEFAULT_SETTINGS.themeAutomation },
+    shortcuts: { ...DEFAULT_SETTINGS.shortcuts },
     performanceMode: DEFAULT_SETTINGS.performanceMode,
     focusMode: { ...DEFAULT_SETTINGS.focusMode },
     fpsLimit: DEFAULT_SETTINGS.fpsLimit,
@@ -568,6 +574,14 @@ function sanitizeFocusMode(input = {}) {
   return { enabled, dimOpacity, idleTimeout };
 }
 
+function sanitizeShortcuts(input = {}) {
+  return {
+    togglePause: typeof input.togglePause === "string" ? input.togglePause : DEFAULT_SETTINGS.shortcuts.togglePause,
+    toggleHide: typeof input.toggleHide === "string" ? input.toggleHide : DEFAULT_SETTINGS.shortcuts.toggleHide,
+    cycleTheme: typeof input.cycleTheme === "string" ? input.cycleTheme : DEFAULT_SETTINGS.shortcuts.cycleTheme
+  };
+}
+
 function sanitizeSettings(input = {}) {
   const source = migrateLegacySettings(input);
 
@@ -579,6 +593,7 @@ function sanitizeSettings(input = {}) {
     colorMode: pick(source.colorMode, VALID_COLOR_MODES, DEFAULT_SETTINGS.colorMode),
     customColors: customColors,
     themeAutomation: sanitizeThemeAutomation(source.themeAutomation),
+    shortcuts: sanitizeShortcuts(source.shortcuts),
     performanceMode: pick(source.performanceMode, VALID_PERFORMANCE_MODES, DEFAULT_SETTINGS.performanceMode),
     fpsLimit: pick(source.fpsLimit, VALID_FPS_LIMITS, DEFAULT_SETTINGS.fpsLimit),
     focusMode: sanitizeFocusMode(source.focusMode),

--- a/settingsStore.js
+++ b/settingsStore.js
@@ -574,11 +574,12 @@ function sanitizeFocusMode(input = {}) {
   return { enabled, dimOpacity, idleTimeout };
 }
 
-function sanitizeShortcuts(input = {}) {
+function sanitizeShortcuts(input) {
+  const safeInput = (input && typeof input === "object") ? input : {};
   return {
-    togglePause: typeof input.togglePause === "string" ? input.togglePause : DEFAULT_SETTINGS.shortcuts.togglePause,
-    toggleHide: typeof input.toggleHide === "string" ? input.toggleHide : DEFAULT_SETTINGS.shortcuts.toggleHide,
-    cycleTheme: typeof input.cycleTheme === "string" ? input.cycleTheme : DEFAULT_SETTINGS.shortcuts.cycleTheme
+    togglePause: typeof safeInput.togglePause === "string" ? safeInput.togglePause : DEFAULT_SETTINGS.shortcuts.togglePause,
+    toggleHide: typeof safeInput.toggleHide === "string" ? safeInput.toggleHide : DEFAULT_SETTINGS.shortcuts.toggleHide,
+    cycleTheme: typeof safeInput.cycleTheme === "string" ? safeInput.cycleTheme : DEFAULT_SETTINGS.shortcuts.cycleTheme
   };
 }
 


### PR DESCRIPTION
### Description

This PR introduces configurable global keyboard shortcuts (hotkeys) via Electron's `globalShortcut` API. Users can now pause/resume, hide/show, and cycle themes in Paraline globally using keyboard shortcuts without having to right-click the system tray icon. These shortcuts are fully customizable from the Settings window under "System Tweaks".

Closes issue #205 

### Changes

1. **System & Storage Integration**:
   - **Modified** [settingsStore.js](file:///c:/Users/KIRTAN/Downloads/Paraline/settingsStore.js): Added `shortcuts` fields (`togglePause`, `toggleHide`, and `cycleTheme`) to default configurations, settings initialization, and settings sanitation pipelines. Default shortcuts are:
     - Pause/Resume: `Ctrl+Alt+P`
     - Hide/Show: `Ctrl+Alt+H`
     - Cycle Theme: `Ctrl+Alt+T`
   - **Modified** [main.js](file:///c:/Users/KIRTAN/Downloads/Paraline/main.js):
     - Destructured `globalShortcut` from Electron imports.
     - Implemented `registerGlobalShortcuts()` to handle safe global registration (and unregistration of outdated shortcut mappings).
     - Implemented `cycleTheme()` to loop through active visualizer themes.
     - Registered global shortcuts on app startup (`whenReady`) and un-registered them on app close (`will-quit`).
     - Added a hook in `updateSettings()` to re-register hotkeys dynamically if updated in the settings UI.

2. **Settings UI / Configuration**:
   - **Modified** [settings.html](file:///c:/Users/KIRTAN/Downloads/Paraline/settings.html): Created a new "Global Hotkeys" section under "System Tweaks". It contains three text inputs displaying the active keybinds.
   - **Modified** [settings.js](file:///c:/Users/KIRTAN/Downloads/Paraline/settings.js):
     - Implemented input key listeners that record keystroke combinations as they are pressed and automatically format them into Electron-compatible strings (e.g. `Ctrl+Alt+P`).
     - Supports resetting a hotkey to `"None"` by pressing `Backspace` or `Escape`.
     - Loaded hotkeys state upon settings initialization and kept them synchronized in the `onChange` payload receiver.

### Verification Steps

1. Launch Paraline (`npm run dev`).
2. Verify the default shortcuts work in the background:
   - Press `Ctrl+Alt+P` to pause/resume rendering.
   - Press `Ctrl+Alt+H` to hide/show visualizer borders.
   - Press `Ctrl+Alt+T` to cycle active themes.
3. Open the settings window, navigate to **Tweaks**, and click inside any hotkey field.
4. Press custom key combinations (e.g. `Ctrl+Shift+L`) and verify the hotkey saves. Verify the new combination works globally.
5. Press `Backspace` on a keybind field and verify it gets cleared to `None` and stops triggering.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added global keyboard shortcuts for pause/resume, show/hide, and cycle theme.
  * New "Global Hotkeys" section in Tweaks for recording shortcuts (press keys to set, Backspace/Escape to clear).
  * Shortcut fields show "None" when unset and persist across sessions.
  * Shortcuts apply immediately after configuration, importing, resetting, or loading theme profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->