### PR TITLE
fix: apply startup settings in resetAllSettings (issue #207)

### DIFF
--- a/main.js
+++ b/main.js
@@ -509,6 +509,7 @@ function resetCurrentThemeSettings() {
 function resetAllSettings() {
   visualizerSettings = settingsStore.save(createDefaultSettings());
   isPaused = false;
+  applyStartupSettings(visualizerSettings.launchOnStartup);
   sendVisualizerSettings();
   refreshTrayMenu();
 }


### PR DESCRIPTION
Fixes #207 by ensuring Reset All Settings synchronizes OS-level launch on startup preference.

## Description

**Issue #207:** Reset All Settings saves default settings with `launchOnStartup: false` but does not call the same startup-sync path. The UI/settings file can show startup disabled while Electron login item settings remain enabled.

**Fix:** Added `applyStartupSettings(visualizerSettings.launchOnStartup)` to `resetAllSettings()` so default startup preference is applied at the OS level.

## Files Changed
- `main.js`: 1 insertion

## Testing
Manual: Enable Launch on Startup → Reset All Settings → verify OS login item disabled.

This is GSSoC '26 contribution.