### PR TITLE
fix: reset isHidden state in resetAllSettings (issue #208)

### DIFF
--- a/main.js
+++ b/main.js
@@ -509,6 +509,7 @@ function resetCurrentThemeSettings() {
 function resetAllSettings() {
   visualizerSettings = settingsStore.save(createDefaultSettings());
   isPaused = false;
+  isHidden = false;
   sendVisualizerSettings();
   refreshTrayMenu();
 }


### PR DESCRIPTION
Fixes #208 by resetting the visualizer `isHidden` state when Reset All Settings is used.

## Description

**Issue #208:** Reset All Settings saves default settings but does not clear the separate in-memory `isHidden` state. If the visualizer is hidden before resetting, the overlay remains hidden while the rest of settings are restored.

**Fix:** Added `isHidden = false` to `resetAllSettings()` so the visualizer returns to default visible state.

## Files Changed
- `main.js`: 1 insertion

## Testing
Manual: Hide visualizer → Reset All Settings → verify visualizer visible.

This is GSSoC '26 contribution.