### PR TITLE
fix(settings): guard slider label updates against missing elements

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -298,6 +298,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const focusModeControls = document.getElementById('focusModeControls');
     const focusModeDimOpacitySlider = document.getElementById('focus-mode-dim-opacity-slider');
     const focusModeTimeoutSlider = document.getElementById('focus-mode-timeout-slider');
+    const focusModeDimOpacityLabel = document.getElementById('val-focus-mode-dim-opacity');
+    const focusModeTimeoutLabel = document.getElementById('val-focus-mode-timeout');
 
     function toggleFocusModeControls(isEnabled) {
         if (focusModeControls) {
@@ -327,7 +329,9 @@ document.addEventListener('DOMContentLoaded', () => {
     if (focusModeDimOpacitySlider) {
         focusModeDimOpacitySlider.addEventListener('input', (e) => {
             const val = parseFloat(e.target.value);
-            document.getElementById('val-focus-mode-dim-opacity').textContent = val.toFixed(2);
+            if (focusModeDimOpacityLabel) {
+                focusModeDimOpacityLabel.textContent = val.toFixed(2);
+            }
             updateFocusModeSetting({ dimOpacity: val });
         });
     }
@@ -335,7 +339,9 @@ document.addEventListener('DOMContentLoaded', () => {
     if (focusModeTimeoutSlider) {
         focusModeTimeoutSlider.addEventListener('input', (e) => {
             const val = parseInt(e.target.value, 10);
-            document.getElementById('val-focus-mode-timeout').textContent = val;
+            if (focusModeTimeoutLabel) {
+                focusModeTimeoutLabel.textContent = val;
+            }
             updateFocusModeSetting({ idleTimeout: val });
         });
     }
@@ -1115,11 +1121,15 @@ refreshThemeProfiles();
                 }
                 if (focusModeDimOpacitySlider) {
                     focusModeDimOpacitySlider.value = fm.dimOpacity !== undefined ? fm.dimOpacity : 0.1;
-                    document.getElementById('val-focus-mode-dim-opacity').textContent = parseFloat(focusModeDimOpacitySlider.value).toFixed(2);
+                    if (focusModeDimOpacityLabel) {
+                        focusModeDimOpacityLabel.textContent = parseFloat(focusModeDimOpacitySlider.value).toFixed(2);
+                    }
                 }
                 if (focusModeTimeoutSlider) {
                     focusModeTimeoutSlider.value = fm.idleTimeout !== undefined ? fm.idleTimeout : 5;
-                    document.getElementById('val-focus-mode-timeout').textContent = focusModeTimeoutSlider.value;
+                    if (focusModeTimeoutLabel) {
+                        focusModeTimeoutLabel.textContent = focusModeTimeoutSlider.value;
+                    }
                 }
             }
             
@@ -1221,11 +1231,15 @@ refreshThemeProfiles();
                 }
                 if (focusModeDimOpacitySlider && fm.dimOpacity !== undefined) {
                     focusModeDimOpacitySlider.value = fm.dimOpacity;
-                    document.getElementById('val-focus-mode-dim-opacity').textContent = parseFloat(fm.dimOpacity).toFixed(2);
+                    if (focusModeDimOpacityLabel) {
+                        focusModeDimOpacityLabel.textContent = parseFloat(fm.dimOpacity).toFixed(2);
+                    }
                 }
                 if (focusModeTimeoutSlider && fm.idleTimeout !== undefined) {
                     focusModeTimeoutSlider.value = fm.idleTimeout;
-                    document.getElementById('val-focus-mode-timeout').textContent = fm.idleTimeout;
+                    if (focusModeTimeoutLabel) {
+                        focusModeTimeoutLabel.textContent = fm.idleTimeout;
+                    }
                 }
             }
 


### PR DESCRIPTION
## Related Issue
Closes #230

## Description

Fixed potential runtime errors in the Settings page by safely checking for slider label elements before updating their text content.

Previously, the script attempted to update label spans such as `val-focus-mode-dim-opacity` and `val-focus-mode-timeout` without verifying that the elements existed in the DOM. If these labels were removed or renamed, the script could throw errors and interrupt other settings functionality.

## Changes Made

- Added null checks before updating slider label text
- Prevented DOM errors when label elements are missing
- Improved resilience of Settings page scripts
- Preserved existing slider functionality when labels are present
- Reduced risk of unrelated settings features breaking due to missing elements

## Steps to Test

1. Open the Settings page
2. Verify slider labels update normally when present
3. Remove or temporarily hide the slider label elements
4. Reload the page
5. Verify no JavaScript errors occur
6. Confirm other settings functionality continues to work

## Expected Result

- No runtime errors when label elements are missing
- Settings page remains functional
- Slider values update labels when the elements exist

## Files Changed

- `settings.js`

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update