### PR TITLE
fix(security): add rel attributes to external settings link

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -730,7 +730,7 @@
                         </div>
 
                         <p class="about-credit">
-                            Built with care by <a href="https://github.com/SamXop123" target="_blank">SamXop123</a>
+                            Built with care by <a href="https://github.com/SamXop123" target="_blank" rel="noopener noreferrer">SamXop123</a>
                         </p>
                     </div>
                 </div>
@@ -741,3 +741,4 @@
 </body>
 
 </html>
+


### PR DESCRIPTION
## Related Issue
Closes #228

## Description

Fixed a security issue in the Settings page by adding `rel="noopener noreferrer"` to the external GitHub repository link.

Previously, the link used `target="_blank"` without the corresponding `rel` attributes. This could allow the opened page to access `window.opener` and potentially manipulate the original application window.

## Changes Made

- Added `rel="noopener noreferrer"` to the external GitHub link
- Preserved existing `target="_blank"` behavior
- Improved security for external navigation
- Followed modern web security best practices

## Steps to Test

1. Open the Settings page
2. Navigate to the About section
3. Inspect the GitHub repository link
4. Verify the link contains:
   ```html
   target="_blank"
   rel="noopener noreferrer"