### PR TITLE
feat: expose full settings backup export/import in Settings UI

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -118,5 +118,11 @@ contextBridge.exposeInMainWorld("paralineApp", {
     ipcRenderer.invoke("theme-profiles:reset"),
 
   resetActiveThemeSettings: () =>
-    ipcRenderer.invoke("theme-profiles:reset-current")
+    ipcRenderer.invoke("theme-profiles:reset-current"),
+
+  exportAllSettings: () =>
+    ipcRenderer.invoke("settings:export-all"),
+
+  importAllSettings: () =>
+    ipcRenderer.invoke("settings:import-all")
 });

--- a/settings.html
+++ b/settings.html
@@ -472,6 +472,23 @@
                         </button>
                     </div>
                 </div>
+
+                <div class="settings-group">
+                    <h3>Settings Backup</h3>
+                    <p class="setting-desc">
+                        Export or restore all app settings and theme profiles in one backup file.
+                    </p>
+
+                    <div style="display: flex; gap: 10px; margin-top: 14px; flex-wrap: wrap;">
+                        <button id="btn-export-all-settings" class="btn-secondary">
+                            Export All Settings
+                        </button>
+
+                        <button id="btn-import-all-settings" class="btn-secondary">
+                            Import Settings Backup
+                        </button>
+                    </div>
+                </div>
             </section>
 
             <!-- Tweaks Settings Tab -->

--- a/settings.js
+++ b/settings.js
@@ -421,6 +421,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const btnDeleteThemeProfile = document.getElementById('btn-delete-theme-profile');
     const btnExportThemeProfile = document.getElementById('btn-export-theme-profile');
     const btnImportThemeProfile = document.getElementById('btn-import-theme-profile');
+    const btnExportAllSettings = document.getElementById('btn-export-all-settings');
+    const btnImportAllSettings = document.getElementById('btn-import-all-settings');
     const btnResetThemeProfile = document.getElementById('btn-reset-theme-profile');
     const btnDuplicateThemeProfile = document.getElementById("btnDuplicateThemeProfile");
 
@@ -954,6 +956,35 @@ refreshThemeProfiles();
                 alert(`Failed to import theme: ${res.error}`);
             }
         });
+
+        if (btnExportAllSettings) {
+            btnExportAllSettings.addEventListener('click', async () => {
+                const res = await window.paralineApp.exportAllSettings();
+
+                if (res && res.success) {
+                    alert("Settings backup exported successfully!");
+                } else if (res && res.error) {
+                    alert(`Failed to export settings backup: ${res.error}`);
+                }
+            });
+        }
+
+        if (btnImportAllSettings) {
+            btnImportAllSettings.addEventListener('click', async () => {
+                if (!confirm("Import a settings backup? This will replace your current settings and theme profiles.")) {
+                    return;
+                }
+
+                const res = await window.paralineApp.importAllSettings();
+
+                if (res && res.success) {
+                    alert("Settings backup imported successfully! The app will reload to apply changes.");
+                    location.reload();
+                } else if (res && res.error) {
+                    alert(`Failed to import settings backup: ${res.error}`);
+                }
+            });
+        }
 
         btnResetThemeProfile.addEventListener('click', async () => {
             if (confirm("Are you sure you want to restore default settings? This will reset all your theme customizations.")) {


### PR DESCRIPTION
Fixes Issue #243 

### Changes
1. preload.js — Exposed IPC methods on paralineApp:

- exportAllSettings() → settings:export-all
- importAllSettings() → settings:import-all

2. settings.html — Added a Settings Backup section under Advanced (below Theme Profiles) with:

- Export All Settings
- Import Settings Backup

3. settings.js — Wired button handlers with feedback:

- Export: success alert, or error alert if something fails (cancel = no alert, same as theme profile export)
- Import: confirmation dialog, then success + page reload, or error alert

### How to test

1. Run npm run dev
2. Open Settings → Advanced
3. Scroll to Settings Backup
4. Export All Settings → choose a path → confirm success alert
5. Import Settings Backup → pick the file → confirm → page reloads with restored settings 