### PR TITLE
fix: validate profile name in settings UI to avoid silent save failure

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -875,12 +875,43 @@ refreshThemeProfiles();
                 }
             });
         }
+        function isValidProfileName(name) {
+            if (typeof name !== "string" || name.trim() === "") {
+                return { valid: false, message: "Profile name cannot be empty." };
+            }
+            if (name.length > 64) {
+                return { valid: false, message: "Profile name cannot exceed 64 characters." };
+            }
+            const reserved = new Set(["__proto__", "constructor", "prototype"]);
+            if (reserved.has(name)) {
+                return { valid: false, message: `Profile name "${name}" is a reserved system word. Please use a different name.` };
+            }
+            const safePattern = /^[A-Za-z0-9 _\-()À-ɏ]{1,64}$/;
+            if (!safePattern.test(name)) {
+                return { valid: false, message: "Profile name contains invalid characters. Use only letters, numbers, spaces, hyphens, underscores, or parentheses." };
+            }
+            return { valid: true };
+        }
+
         btnSaveThemeProfile.addEventListener('click', async () => {
             const profileName = themeProfileNameInput.value.trim();
 
-            if (!profileName) return;
+            if (!profileName) {
+                alert("Profile name cannot be empty.");
+                return;
+            }
 
-            await window.paralineApp.saveThemeProfile(profileName);
+            const validation = isValidProfileName(profileName);
+            if (!validation.valid) {
+                alert(validation.message);
+                return;
+            }
+
+            const result = await window.paralineApp.saveThemeProfile(profileName);
+            if (!result) {
+                alert(`Failed to save profile "${profileName}". The name is invalid or rejected by the system.`);
+                return;
+            }
 
             themeProfileNameInput.value = '';
             alert(`Theme profile "${profileName}" saved!`);


### PR DESCRIPTION
### Description
When creating a theme profile in the Settings panel under Advanced, the UI previously accepted any profile name string and called the backend IPC saveThemeProfile API. However, the backend validation rejects names containing invalid characters (e.g. /), reserved keys (e.g. __proto__), or names exceeding 64 characters by returning null. Because the settings UI did not inspect the response and had no validation of its own, these invalid profile names failed silently with a success alert shown despite not actually being saved.

Fixes Issue #259 

This PR resolves the issue by:

1. Implementing frontend validation in settings.js (isValidProfileName) that mirrors the main process validation rules (e.g. checks for empty, length limit > 64, reserved keywords __proto__, constructor, prototype, and invalid characters using regex /^[A-Za-z0-9 _\-()À-ɏ]{1,64}$/).
2. Showing clear, descriptive warning alerts on specific validation failures (e.g., empty string, reserved keyword, name length, or invalid character usage).
3. Verifying the return value from the window.paralineApp.saveThemeProfile IPC call, showing an error if it returns null or falsy, and only showing the success alert when it succeeds.

### How to Test
1. Open settings window, go to Advanced → Theme Profiles.
2. Enter an invalid profile name:
    - My/Profile (contains slash)
    - __proto__ (reserved keyword)
    - A name exceeding 64 characters
3. Click "Save".
4. Verify that the correct alert describes the validation issue (e.g., "Profile name contains invalid characters...") and the input is not cleared or saved.
5. Enter a valid name (e.g. Profile-1 (Draft)) and click "Save". Verify that a success alert is shown and the profile is saved.