### PR TITLE
fix: validate contact form fields and payload size in API route

### DIFF
--- a/landing/src/app/api/contact/route.ts
+++ b/landing/src/app/api/contact/route.ts
@@ -2,24 +2,122 @@ import { NextResponse } from "next/server";
 
 export async function POST(request: Request) {
   try {
-    const body = await request.json();
+    // Protect against oversized payloads by checking content-length header
+    const contentLength = request.headers.get("content-length");
+    if (contentLength && parseInt(contentLength, 10) > 100 * 1024) { // 100KB limit
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Payload too large. Maximum size is 100KB.",
+        },
+        { status: 413 }
+      );
+    }
 
+    const body = await request.json();
     const { name, email, subject, message } = body;
 
+    // Validate presence of required fields first
     if (!name || !email || !message) {
       return NextResponse.json(
         {
           success: false,
-          error: "Missing required fields.",
+          error: "Name, email, and message are required and cannot be empty.",
         },
         { status: 400 }
       );
     }
 
-   console.info("[CONTACT_FORM] submission received", {
-  hasSubject: Boolean(subject),
-  messageLength: message.length,
-});
+    // Validate that inputs are strings
+    if (
+      typeof name !== "string" ||
+      typeof email !== "string" ||
+      typeof message !== "string" ||
+      (subject !== undefined && typeof subject !== "string")
+    ) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Invalid input types. Fields must be strings.",
+        },
+        { status: 400 }
+      );
+    }
+
+    const trimmedName = name.trim();
+    const trimmedEmail = email.trim();
+    const trimmedMessage = message.trim();
+    const trimmedSubject = subject ? subject.trim() : "";
+
+    // Validate trimmed fields are not empty
+    if (!trimmedName || !trimmedEmail || !trimmedMessage) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Name, email, and message are required and cannot be empty.",
+        },
+        { status: 400 }
+      );
+    }
+
+    // Validate email format
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(trimmedEmail)) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Invalid email format.",
+        },
+        { status: 400 }
+      );
+    }
+
+    // Validate reasonable maximum character lengths
+    if (trimmedName.length > 100) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Name cannot exceed 100 characters.",
+        },
+        { status: 400 }
+      );
+    }
+
+    if (trimmedEmail.length > 256) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Email cannot exceed 256 characters.",
+        },
+        { status: 400 }
+      );
+    }
+
+    if (trimmedSubject.length > 200) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Subject cannot exceed 200 characters.",
+        },
+        { status: 400 }
+      );
+    }
+
+    if (trimmedMessage.length > 5000) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Message cannot exceed 5000 characters.",
+        },
+        { status: 400 }
+      );
+    }
+
+    console.info("[CONTACT_FORM] submission received", {
+      hasSubject: Boolean(trimmedSubject),
+      messageLength: trimmedMessage.length,
+    });
+
     return NextResponse.json({
       success: true,
       message: "Message received successfully.",

--- a/landing/src/app/api/contact/route.ts
+++ b/landing/src/app/api/contact/route.ts
@@ -155,7 +155,10 @@ export async function POST(request: Request) {
             },
             {
               name: "Message",
-              value: trimmedMessage,
+              value:
+                trimmedMessage.length > 1024
+                  ? trimmedMessage.substring(0, 1021) + "..."
+                  : trimmedMessage,
               inline: false,
             },
           ],

--- a/landing/src/app/contact/page.jsx
+++ b/landing/src/app/contact/page.jsx
@@ -157,6 +157,7 @@ export default function ContactPage() {
                     value={form.name}
                     onChange={handleChange}
                     required
+                    maxLength={100}
                     className="w-full p-4 rounded-2xl bg-[#010206]/40 border border-white/5 text-white outline-none focus:border-cyan-500/40 focus:bg-[#010206]/60 transition-all placeholder:text-white/25 text-sm"
                   />
                 </div>
@@ -173,6 +174,7 @@ export default function ContactPage() {
                     value={form.email}
                     onChange={handleChange}
                     required
+                    maxLength={256}
                     className="w-full p-4 rounded-2xl bg-[#010206]/40 border border-white/5 text-white outline-none focus:border-cyan-500/40 focus:bg-[#010206]/60 transition-all placeholder:text-white/25 text-sm"
                   />
                 </div>
@@ -189,6 +191,7 @@ export default function ContactPage() {
                   placeholder="How can we help?"
                   value={form.subject}
                   onChange={handleChange}
+                  maxLength={200}
                   className="w-full p-4 rounded-2xl bg-[#010206]/40 border border-white/5 text-white outline-none focus:border-cyan-500/40 focus:bg-[#010206]/60 transition-all placeholder:text-white/25 text-sm"
                 />
               </div>
@@ -205,6 +208,7 @@ export default function ContactPage() {
                   value={form.message}
                   onChange={handleChange}
                   required
+                  maxLength={5000}
                   className="w-full p-4 rounded-2xl bg-[#010206]/40 border border-white/5 text-white outline-none focus:border-cyan-500/40 focus:bg-[#010206]/60 transition-all placeholder:text-white/25 text-sm resize-none"
                 />
               </div>


### PR DESCRIPTION
## Description
The contact API POST route (`landing/src/app/api/contact/route.ts`) previously performed only a simple presence check for form inputs. It did not validate email format, enforce max lengths, check variable types, or protect against oversized payloads. Consequently, malformed emails, massive message content, or huge payloads could be submitted successfully.

Fixes Issue #260 

This PR implements robust backend validation for the contact API:
1. **Payload Size Limitation**: Rejects requests exceeding 100KB with status `413 (Payload Too Large)` based on the `Content-Length` header.
2. **Type Checking**: Validates that all incoming fields are of type `string` (rejecting objects, arrays, or numbers) with status `400 (Bad Request)`.
3. **Email Address Validation**: Checks the input email format against a standard regex pattern (`/^[^\s@]+@[^\s@]+\.[^\s@]+$/`) to reject malformed emails.
4. **Length Constraints**: Restricts field lengths (e.g. name to 100 chars, email to 256 chars, subject to 200 chars, and message to 5000 chars) to prevent oversized database insertions or payload-based resource exhaustion.
5. **Validation Order**: Checks for presence of parameters first so missing-field errors are clearer.

## How to Test
1. Set up and run the landing server (`npm run dev` in the `landing` directory).
2. Send test requests to `/api/contact`:
   - Send a request with a missing required field (e.g. message omitted) and verify a `400` status with a descriptive error.
   - Send a request with a malformed email (e.g. `not-an-email`) and verify a `400` status with "Invalid email format".
   - Send a request with a message exceeding 5000 characters and verify a `400` status with "Message cannot exceed 5000 characters".
   - Send a request with a `Content-Length` header set above 100KB and verify a `413` status with "Payload too large".
   - Send a valid request and verify a successful `200` status.
