### PR TITLE
feat: add unit tests for settingsStore sanitization and migration logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
     "audio:helper:info": "node -e \"console.log('Paraline is Windows-only. Build the helper with: dotnet build ./audio-helper/Paraline.AudioBridge.csproj')\"",
     "build:helper": "dotnet publish .\\audio-helper\\Paraline.AudioBridge.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o .\\build\\audio-helper",
     "pack:win": "npm run build:helper && npm run validate:helper && electron-builder --dir --win nsis --x64",
-  "dist:win": "npm run build:helper && npm run validate:helper && electron-builder --win nsis --x64",
-    "validate:helper": "node scripts/validate-helper.js"
+    "dist:win": "npm run build:helper && npm run validate:helper && electron-builder --win nsis --x64",
+    "validate:helper": "node scripts/validate-helper.js",
+    "test": "node --test test/**/*.test.js"
   },
   "keywords": [
     "electron",

--- a/test/settingsStore.test.js
+++ b/test/settingsStore.test.js
@@ -1,0 +1,109 @@
+const test = require("node:test");
+const assert = require("node:assert");
+const {
+  DEFAULT_SETTINGS,
+  createDefaultSettings,
+  createThemeDefaults,
+  sanitizeSettings
+} = require("../settingsStore");
+
+test("settingsStore - Default Settings Creation", () => {
+  const defaults = createDefaultSettings();
+  assert.ok(defaults.onboardingSeen === false);
+  assert.ok(defaults.selectedTheme === "ambientWave");
+  assert.deepStrictEqual(defaults.ambientWave.tone, "blue");
+});
+
+test("settingsStore - sanitizeSettings with empty/invalid inputs", () => {
+  const sanitized = sanitizeSettings({});
+  assert.strictEqual(sanitized.onboardingSeen, false);
+  assert.strictEqual(sanitized.selectedTheme, "ambientWave");
+  assert.deepStrictEqual(sanitized.customColors, ["#00f2fe", "#4facfe", "#8ee2ff"]);
+  assert.strictEqual(sanitized.themeAutomation.enabled, false);
+});
+
+test("settingsStore - sanitizeSettings clamps custom thickness, gap, sensitivity, speed", () => {
+  const input = {
+    selectedTheme: "ambientWave",
+    sideBars: {
+      customThickness: 100,      // should clamp to 20
+      customGap: 0,             // should clamp to 2
+      customSensitivity: -50,   // should clamp to 1
+    },
+    sideBraids: {
+      customSpeed: 500          // should clamp to 100
+    }
+  };
+  const sanitized = sanitizeSettings(input);
+  assert.strictEqual(sanitized.sideBars.customThickness, 20);
+  assert.strictEqual(sanitized.sideBars.customGap, 2);
+  assert.strictEqual(sanitized.sideBars.customSensitivity, 1);
+  assert.strictEqual(sanitized.sideBraids.customSpeed, 100);
+});
+
+test("settingsStore - sanitizeSettings validates customColors array length and format", () => {
+  // Test invalid length
+  const inputInvalidLen = {
+    selectedTheme: "ambientWave",
+    customColors: ["#ffffff", "#000000"]
+  };
+  const sanitized1 = sanitizeSettings(inputInvalidLen);
+  assert.deepStrictEqual(sanitized1.customColors, DEFAULT_SETTINGS.customColors);
+
+  // Test invalid hex format
+  const inputInvalidHex = {
+    selectedTheme: "ambientWave",
+    customColors: ["#ffffff", "#000000", "invalid"]
+  };
+  const sanitized2 = sanitizeSettings(inputInvalidHex);
+  assert.deepStrictEqual(sanitized2.customColors, DEFAULT_SETTINGS.customColors);
+
+  // Test valid hex format
+  const inputValid = {
+    selectedTheme: "ambientWave",
+    customColors: ["#111111", "#222222", "#333333"]
+  };
+  const sanitized3 = sanitizeSettings(inputValid);
+  assert.deepStrictEqual(sanitized3.customColors, ["#111111", "#222222", "#333333"]);
+});
+
+test("settingsStore - Legacy Migration (edgeFlutter to edgeCrystals)", () => {
+  const legacyInput = {
+    selectedTheme: "edgeFlutter",
+    edgeFlutter: {
+      flutterStyle: "energetic",
+      density: "high"
+    }
+  };
+  const sanitized = sanitizeSettings(legacyInput);
+  assert.strictEqual(sanitized.selectedTheme, "edgeCrystals");
+  assert.strictEqual(sanitized.edgeCrystals.flutterStyle, "energetic");
+  assert.strictEqual(sanitized.edgeCrystals.density, "high");
+});
+
+test("settingsStore - Legacy Theme Automation Migration", () => {
+  const input = {
+    selectedTheme: "ambientWave",
+    themeAutomation: {
+      enabled: true,
+      checkIntervalMinutes: 200, // should clamp to 120
+      dayStartHour: 25,          // should fall back to default
+      nightStartHour: -2         // should fall back to default
+    }
+  };
+  const sanitized = sanitizeSettings(input);
+  assert.strictEqual(sanitized.themeAutomation.enabled, true);
+  assert.strictEqual(sanitized.themeAutomation.checkIntervalMinutes, 120);
+  assert.strictEqual(sanitized.themeAutomation.dayStartHour, DEFAULT_SETTINGS.themeAutomation.dayStartHour);
+  assert.strictEqual(sanitized.themeAutomation.nightStartHour, DEFAULT_SETTINGS.themeAutomation.nightStartHour);
+});
+
+test("settingsStore - Legacy Theme conversion (sensitivity mapping)", () => {
+  const legacy = {
+    theme: "rainbow",
+    sensitivity: 5.0
+  };
+  const sanitized = sanitizeSettings(legacy);
+  assert.strictEqual(sanitized.selectedTheme, "reactiveBorder");
+  assert.strictEqual(sanitized.reactiveBorder.intensity, "high");
+});


### PR DESCRIPTION
## Description
Paraline had no automated tests, leaving critical sanitization, validation, and
legacy-migration logic in `settingsStore.js` untested and prone to silent regressions.

This PR introduces a unit test suite using Node.js's built-in `node:test` runner —
no additional test dependencies required.

Fixes Issue #261 

### What Was Added

#### `test/settingsStore.test.js`
7 unit tests covering default settings creation, empty-input sanitization, custom
value clamping bounds, `customColors` hex format validation, legacy `edgeFlutter →
edgeCrystals` migration, `themeAutomation` interval/hour clamping, and legacy theme
name conversion with sensitivity mapping.

#### `package.json`
Added `"test"` script:
```json
"test": "node --test test/**/*.test.js"
