### PR TITLE
test: add unit tests for settingsStore sanitization logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
     "audio:helper:info": "node -e \"console.log('Paraline is Windows-only. Build the helper with: dotnet build ./audio-helper/Paraline.AudioBridge.csproj')\"",
     "build:helper": "dotnet publish .\\audio-helper\\Paraline.AudioBridge.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o .\\build\\audio-helper",
     "pack:win": "npm run build:helper && npm run validate:helper && electron-builder --dir --win nsis --x64",
-  "dist:win": "npm run build:helper && npm run validate:helper && electron-builder --win nsis --x64",
-    "validate:helper": "node scripts/validate-helper.js"
+    "dist:win": "npm run build:helper && npm run validate:helper && electron-builder --win nsis --x64",
+    "validate:helper": "node scripts/validate-helper.js",
+    "test": "node --test"
   },
   "keywords": [
     "electron",

--- a/tests/settingsStore.test.js
+++ b/tests/settingsStore.test.js
@@ -1,0 +1,49 @@
+const assert = require("node:assert");
+const test = require("node:test");
+const { sanitizeSettings, DEFAULT_SETTINGS } = require("../settingsStore");
+
+test("sanitizeSettings should return DEFAULT_SETTINGS for empty input", () => {
+  const result = sanitizeSettings({});
+  assert.strictEqual(result.launchOnStartup, DEFAULT_SETTINGS.launchOnStartup);
+  assert.strictEqual(result.selectedTheme, DEFAULT_SETTINGS.selectedTheme);
+  
+  const expectedAmbientWave = {
+    ...DEFAULT_SETTINGS.ambientWave,
+    customColors: DEFAULT_SETTINGS.customColors,
+    customSensitivity: 30
+  };
+  assert.deepStrictEqual(result.ambientWave, expectedAmbientWave);
+});
+
+test("sanitizeSettings should fallback to DEFAULT_SETTINGS.selectedTheme for invalid theme", () => {
+  const result = sanitizeSettings({ selectedTheme: "invalidThemeName" });
+  assert.strictEqual(result.selectedTheme, DEFAULT_SETTINGS.selectedTheme);
+});
+
+test("sanitizeSettings should parse launchOnStartup correctly", () => {
+  let result = sanitizeSettings({ selectedTheme: "ambientWave", launchOnStartup: true });
+  assert.strictEqual(result.launchOnStartup, true);
+
+  result = sanitizeSettings({ selectedTheme: "ambientWave", launchOnStartup: "true" }); // Invalid type should fallback to default
+  assert.strictEqual(result.launchOnStartup, false);
+});
+
+
+
+test("sanitizeSettings should sanitize inner theme objects", () => {
+  const invalidAmbientWave = {
+    tone: "invalidTone",
+    sensitivity: "invalidSensitivity"
+  };
+  const result = sanitizeSettings({ selectedTheme: "ambientWave", ambientWave: invalidAmbientWave });
+  assert.strictEqual(result.ambientWave.tone, DEFAULT_SETTINGS.ambientWave.tone);
+  assert.strictEqual(result.ambientWave.sensitivity, DEFAULT_SETTINGS.ambientWave.sensitivity);
+});
+
+test("sanitizeSettings should migrate legacy settings correctly", () => {
+  const legacySettings = {
+    theme: "purple" // Legacy theme tone
+  };
+  const result = sanitizeSettings(legacySettings);
+  assert.strictEqual(result.ambientWave.tone, "purple");
+});


### PR DESCRIPTION
Resolves #261. Added unit tests to ensure settingsStore settings sanitization and migration logic works reliably and avoids regressions.