### PR TITLE
docs: fix heading hierarchy in Usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ And it should still feel good.
 
 ## ✦ Usage
 
-## Tray Controls
+### Tray Controls
 
 Paraline is designed to stay visually present but operationally invisible.
 


### PR DESCRIPTION
Description
This PR fixes a minor markdown formatting issue in the "Usage" section of the README.md file to improve document structure.

issue #None

Changes Made
Updated the "Tray Controls" heading from a Level 2 (##) to a Level 3 (###).

Previously, it was at the same hierarchy level as the main "Usage" header. This change properly nests it as a subsection, fixing the document's logical flow and improving compatibility with auto-generated tables of contents.