### PR TITLE
fix: handle identical theme automation hours

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -614,6 +614,7 @@
                                 <input type="number" id="nightStartHourInput" min="0" max="23" value="18" style="width: 60px; margin-left: 10px;" />
                             </div>
                         </div>
+                        <div id="theme-automation-error" style="color: #e74c3c; font-size: 13px; margin-top: 5px; font-weight: 500; height: 18px; opacity: 0; transition: opacity 0.3s ease;"></div>
 
                         <div class="input-group" style="margin-top: 10px;">
                             <label id="dayThemeLabel">Daytime Theme (6 AM - 6 PM):</label>

--- a/settings.js
+++ b/settings.js
@@ -221,6 +221,18 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
+    let automationErrorTimeout = null;
+    function showAutomationError(message) {
+        const errorEl = document.getElementById('theme-automation-error');
+        if (!errorEl) return;
+        errorEl.textContent = message;
+        errorEl.style.opacity = '1';
+        if (automationErrorTimeout) clearTimeout(automationErrorTimeout);
+        automationErrorTimeout = setTimeout(() => {
+            errorEl.style.opacity = '0';
+        }, 3000);
+    }
+
     function toggleAutoControls(isEnabled) {
         if (themeAutoControls) {
             themeAutoControls.style.display = isEnabled ? 'block' : 'none';
@@ -272,8 +284,13 @@ document.addEventListener('DOMContentLoaded', () => {
                 val = 6;
                 dayStartHourInput.value = val;
             }
-            updateAutomationSetting({ dayStartHour: val });
             const nightStart = nightStartHourInput ? parseInt(nightStartHourInput.value, 10) : 18;
+            if (val === nightStart) {
+                showAutomationError("Day and Night hours cannot be identical.");
+                val = cachedSettings.themeAutomation?.dayStartHour ?? 6;
+                dayStartHourInput.value = val;
+            }
+            updateAutomationSetting({ dayStartHour: val });
             updateThemeLabels(val, isNaN(nightStart) ? 18 : nightStart);
         });
     }
@@ -285,8 +302,13 @@ document.addEventListener('DOMContentLoaded', () => {
                 val = 18;
                 nightStartHourInput.value = val;
             }
-            updateAutomationSetting({ nightStartHour: val });
             const dayStart = dayStartHourInput ? parseInt(dayStartHourInput.value, 10) : 6;
+            if (val === dayStart) {
+                showAutomationError("Day and Night hours cannot be identical.");
+                val = cachedSettings.themeAutomation?.nightStartHour ?? 18;
+                nightStartHourInput.value = val;
+            }
+            updateAutomationSetting({ nightStartHour: val });
             updateThemeLabels(isNaN(dayStart) ? 6 : dayStart, val);
         });
     }

--- a/settingsStore.js
+++ b/settingsStore.js
@@ -311,6 +311,11 @@ function sanitizeThemeAutomation(input = {}) {
     nightStart = DEFAULT_SETTINGS.themeAutomation.nightStartHour;
   }
 
+  if (dayStart === nightStart) {
+    dayStart = DEFAULT_SETTINGS.themeAutomation.dayStartHour;
+    nightStart = DEFAULT_SETTINGS.themeAutomation.nightStartHour;
+  }
+
   return {
     enabled: typeof input.enabled === "boolean" ? input.enabled : DEFAULT_SETTINGS.themeAutomation.enabled,
     checkIntervalMinutes: typeof input.checkIntervalMinutes === "number"

--- a/test/settingsStore.test.js
+++ b/test/settingsStore.test.js
@@ -98,6 +98,18 @@ test("settingsStore - Legacy Theme Automation Migration", () => {
   assert.strictEqual(sanitized.themeAutomation.nightStartHour, DEFAULT_SETTINGS.themeAutomation.nightStartHour);
 });
 
+test("settingsStore - Theme Automation avoids equal hours", () => {
+  const input = {
+    themeAutomation: {
+      dayStartHour: 10,
+      nightStartHour: 10
+    }
+  };
+  const sanitized = sanitizeSettings(input);
+  assert.strictEqual(sanitized.themeAutomation.dayStartHour, DEFAULT_SETTINGS.themeAutomation.dayStartHour);
+  assert.strictEqual(sanitized.themeAutomation.nightStartHour, DEFAULT_SETTINGS.themeAutomation.nightStartHour);
+});
+
 test("settingsStore - Legacy Theme conversion (sensitivity mapping)", () => {
   const legacy = {
     theme: "rainbow",

--- a/themeAgent.js
+++ b/themeAgent.js
@@ -52,8 +52,13 @@ class ThemeAgent {
 
     try {
       const currentHour = new Date().getHours();
-      const dayStartHour = config.dayStartHour !== undefined ? config.dayStartHour : 6;
-      const nightStartHour = config.nightStartHour !== undefined ? config.nightStartHour : 18;
+      let dayStartHour = config.dayStartHour !== undefined ? config.dayStartHour : 6;
+      let nightStartHour = config.nightStartHour !== undefined ? config.nightStartHour : 18;
+
+      if (dayStartHour === nightStartHour) {
+        dayStartHour = 6;
+        nightStartHour = 18;
+      }
 
       let isDaytime;
       if (dayStartHour < nightStartHour) {


### PR DESCRIPTION
## Summary

Fixes #274 by preventing invalid theme automation schedules where Day Start Hour and Night Start Hour are identical.

## Changes

- Added frontend validation for identical day/night hours
- Added user-facing validation message in settings UI
- Reverted invalid selections to the last valid value
- Added configuration sanitization fallback
- Added runtime safeguard in themeAgent
- Added regression test covering equal-hour configurations

## Testing

- Ran project test suite
- All tests passing (13/13)