### PR TITLE
fix(#275): update Discord support link

### DIFF
--- a/landing/src/app/contact/page.jsx
+++ b/landing/src/app/contact/page.jsx
@@ -267,7 +267,7 @@ export default function ContactPage() {
               </div>
               <div>
                 <h3 className="text-sm font-semibold tracking-wide text-white mb-1">Discord Support</h3>
-                <a href="https://discord.com" target="_blank" rel="noopener noreferrer" className="text-sm text-cyan-400 hover:underline">
+                <a href="https://discord.gg/YRMUmgNWz" target="_blank" rel="noopener noreferrer" className="text-sm text-cyan-400 hover:underline">
                   @dot_notsam
                 </a>
                 <p className="text-xs text-muted/60 mt-2 font-light leading-relaxed">


### PR DESCRIPTION
### Summary

Fixes #275.

Updated the Discord Support link on the Contact page to use the maintainer-provided Discord invite URL instead of the generic Discord homepage.

### Changes

* Replaced `https://discord.com` with `https://discord.gg/YRMUmgNWz` in `landing/src/app/contact/page.jsx`.
* Kept the displayed Discord handle (`@dot_notsam`) unchanged.

### Testing

* Verified the Contact page renders correctly.
* Verified the Discord Support link opens the maintainer-provided Discord invite in a new tab.