### PR TITLE
fix: improve theme profile import validation error message

### DIFF
--- a/main.js
+++ b/main.js
@@ -2018,7 +2018,7 @@ app.whenReady().then(() => {
 
       const rawProfileName = path.basename(filePath, ".json");
       if (!isValidProfileName(rawProfileName)) {
-        return { success: false, error: "Invalid profile name: the filename contains reserved or disallowed characters." };
+        return { success: false, error: "Invalid profile name: The filename contains unsupported characters. Please rename the file using only letters, numbers, spaces, hyphens, underscores, and parentheses (maximum 64 characters)." };
       }
       const profileName = rawProfileName;
       const profiles = settingsStore.loadProfiles();


### PR DESCRIPTION

## Description

This PR improves the error message shown to the user when importing a theme profile whose filename contains reserved or disallowed characters.

Previously, if a user imported a theme profile with an invalid filename (e.g. `my[profile].json`), it would fail silently or surface a generic and unhelpful error message: `Failed to import theme: Invalid profile name: the filename contains reserved or disallowed characters.`.

Fixes Issue #281 

### Changes

- **Improved Error Message**: Updated the validation error in `main.js` to explicitly state:
  `Invalid profile name: The filename contains unsupported characters. Please rename the file using only letters, numbers, spaces, hyphens, underscores, and parentheses (maximum 64 characters).`
- This provides the user with clear instructions and actionable guidance on how to fix the filename and import it successfully.

---

## Testing

1. Export any existing theme profile.
2. Rename the exported `.json` file to include brackets (e.g., `my[test].json`).
3. Click the **Import** button in Settings → Theme Profiles and select `my[test].json`.
4. Verification: The error toast correctly shows:
   `Failed to import theme: Invalid profile name: The filename contains unsupported characters. Please rename the file using only letters, numbers, spaces, hyphens, underscores, and parentheses (maximum 64 characters).`
