### PR TITLE
fix(#287): clear focus mode polling on app quit

### DIFF
--- a/main.js
+++ b/main.js
@@ -2190,6 +2190,7 @@ app.on("before-quit", () => {
   isQuitting = true;
   stopSimulatedAudioFallback();
   destroyAllOverlayWindows();
+  stopFocusModePolling();
 
   if (audioBridge) {
     audioBridge.stop();


### PR DESCRIPTION
## Description

Adds Focus Mode polling cleanup to the Electron `before-quit` handler.

Previously, `stopFocusModePolling()` was only called from `window-all-closed`, so Focus Mode polling could remain active during shutdown paths such as quitting from the tray or overlay context menu.

## Related Issue

Fixes #287

## Changes Made

- Added `stopFocusModePolling()` to the `before-quit` cleanup path.
- Preserved the existing `window-all-closed` Focus Mode cleanup.
- Kept the change scoped to `main.js`.

## Testing

- `git diff`
- `git diff --check`
- `npm.cmd test` — passed (14/14 tests)
- `npm.cmd pkg get scripts` — confirmed no lint script is available