### PR TITLE
fix(#288): parse automation interval strings

### DIFF
--- a/settingsStore.js
+++ b/settingsStore.js
@@ -330,10 +330,16 @@ function sanitizeThemeAutomation(input = {}) {
     nightStart = DEFAULT_SETTINGS.themeAutomation.nightStartHour;
   }
 
+  const interval = typeof input.checkIntervalMinutes === "number"
+    ? input.checkIntervalMinutes
+    : (typeof input.checkIntervalMinutes === "string" && input.checkIntervalMinutes.trim() !== ""
+      ? Number(input.checkIntervalMinutes)
+      : NaN);
+
   return {
     enabled: typeof input.enabled === "boolean" ? input.enabled : DEFAULT_SETTINGS.themeAutomation.enabled,
-    checkIntervalMinutes: typeof input.checkIntervalMinutes === "number"
-      ? Math.max(1, Math.min(120, input.checkIntervalMinutes))
+    checkIntervalMinutes: Number.isFinite(interval)
+      ? Math.max(1, Math.min(120, interval))
       : DEFAULT_SETTINGS.themeAutomation.checkIntervalMinutes,
     mode: typeof input.mode === "string" ? input.mode : DEFAULT_SETTINGS.themeAutomation.mode,
     dayTheme: pick(input.dayTheme, VALID_MAIN_THEMES, DEFAULT_SETTINGS.themeAutomation.dayTheme),

--- a/test/settingsStore.test.js
+++ b/test/settingsStore.test.js
@@ -98,6 +98,28 @@ test("settingsStore - Legacy Theme Automation Migration", () => {
   assert.strictEqual(sanitized.themeAutomation.nightStartHour, DEFAULT_SETTINGS.themeAutomation.nightStartHour);
 });
 
+test("settingsStore - Theme Automation parses and clamps check interval strings", () => {
+  const cases = [
+    ["15", 15],
+    [15, 15],
+    ["0", 1],
+    ["99999", 120],
+    ["abc", DEFAULT_SETTINGS.themeAutomation.checkIntervalMinutes],
+    [null, DEFAULT_SETTINGS.themeAutomation.checkIntervalMinutes],
+    [{}, DEFAULT_SETTINGS.themeAutomation.checkIntervalMinutes],
+    [[], DEFAULT_SETTINGS.themeAutomation.checkIntervalMinutes]
+  ];
+
+  for (const [checkIntervalMinutes, expected] of cases) {
+    const sanitized = sanitizeSettings({
+      selectedTheme: "ambientWave",
+      themeAutomation: { checkIntervalMinutes }
+    });
+    assert.strictEqual(sanitized.themeAutomation.checkIntervalMinutes, expected);
+    assert.strictEqual(typeof sanitized.themeAutomation.checkIntervalMinutes, "number");
+  }
+});
+
 test("settingsStore - Theme Automation avoids equal hours", () => {
   const input = {
     themeAutomation: {


### PR DESCRIPTION
## Description
Fixes `themeAutomation.checkIntervalMinutes` sanitization so numeric strings like `"15"` are parsed, clamped, and stored as numbers instead of falling back to the default interval.

## Related Issue
Fixes #288

## Changes Made
- Updated `sanitizeThemeAutomation()` to accept numeric strings for `checkIntervalMinutes`.
- Preserved existing clamping behavior for the valid `1..120` range.
- Kept invalid values such as `"abc"`, `null`, `{}`, and `[]` falling back to the default `30`.
- Added focused test coverage for numeric string, numeric, clamped, and invalid interval values.

## Testing
- `npm.cmd test`
- 15 tests passed