### PR TITLE
fix(#289): reset animation clock while hidden

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -619,6 +619,7 @@ function renderFrame(now) {
 
   if (visualizerState.hidden) {
     context.clearRect(0, 0, width, height);
+    lastFrameAt = performance.now();
     return;
   }
 


### PR DESCRIPTION
## Description

This PR fixes an animation timing issue that occurred when the visualizer was hidden. Previously, `lastFrameAt` was not updated while the visualizer was hidden, causing the next visible frame to use the entire hidden duration as `deltaMs`. This could make animated themes jump forward abruptly when the visualizer was shown again.

The fix resets the animation clock while hidden so animations resume smoothly without accumulating stale time.

## Related Issue

Fixes #289

## Changes Made

* Updated the hidden-state path in `renderFrame()`.
* Reset `lastFrameAt` when `visualizerState.hidden` is `true`.
* Prevented hidden duration from being included in the next frame's animation delta.
* Kept the change minimal and limited to `renderer.js`.

## Screenshots (if UI change)

Before: N/A (animation timing issue)

After: N/A (animation timing issue)

## Checklist

* [x] I have read CONTRIBUTING.md
* [x] I have tested my changes locally
* [x] No new console errors
* [x] Linked the issue with 'Fixes #'
