### PR TITLE
fix(#290): add noopener to download fallback

### DIFF
--- a/landing/src/components/DownloadButton.tsx
+++ b/landing/src/components/DownloadButton.tsx
@@ -79,7 +79,11 @@ export function DownloadButton({ className, variant = "primary", children, style
         alert("The download request timed out. Please try again or visit our GitHub releases directly.");
       } else {
         // Fallback
-        window.open("https://github.com/SamXop123/Paraline/releases/latest", "_blank");
+        window.open(
+          "https://github.com/SamXop123/Paraline/releases/latest",
+          "_blank",
+          "noopener,noreferrer"
+        );
       }
     }
   };


### PR DESCRIPTION
## Description

Adds `noopener,noreferrer` to the landing page download fallback that opens the GitHub releases page in a new tab.

Previously, the fallback used `window.open(..., "_blank")` without opener protection, which could allow the newly opened page to retain access to `window.opener`.

## Related Issue

Fixes #290

## Changes Made

* Updated the fallback `window.open()` call in `landing/src/components/DownloadButton.tsx`
* Added `"noopener,noreferrer"` as the third argument
* Kept the change minimal and limited to the affected fallback path

## Security Impact

Prevents the opened tab from accessing `window.opener`, following recommended security practices for links opened in a new tab.

## Testing

* Verified the diff only modifies `landing/src/components/DownloadButton.tsx`
* Ran `git diff --check`
* Inspected the fallback path to confirm `noopener,noreferrer` is applied

## Notes

* Attempted to run `npm.cmd run lint`, but linting could not complete because `eslint` was not installed/resolvable in the local landing environment.
