### PR TITLE
fix(#286): validate backup profile names on import

### DIFF
--- a/main.js
+++ b/main.js
@@ -727,6 +727,26 @@ function isValidProfileName(name) {
   return SAFE_PROFILE_NAME_RE.test(name);
 }
 
+function sanitizeBackupProfiles(profiles = {}) {
+  const safeProfiles = {};
+
+  for (const [name, profile] of Object.entries(profiles || {})) {
+    if (
+      typeof name !== "string" ||
+      name === "__proto__" ||
+      name === "constructor" ||
+      name === "prototype" ||
+      !isValidProfileName(name)
+    ) {
+      continue;
+    }
+
+    safeProfiles[name] = sanitizeSettings(profile || {});
+  }
+
+  return safeProfiles;
+}
+
 function hasThemeProfile(profiles, profileName) {
   return Object.prototype.hasOwnProperty.call(profiles, profileName);
 }
@@ -2083,21 +2103,7 @@ app.whenReady().then(() => {
 
       settingsStore.save(cleanSettings);
 
-    const safeProfiles = {};
-
-    for (const [name, profile] of Object.entries(importedBackup.profiles || {})) {
-
-        if (
-            typeof name !== "string" ||
-            name === "__proto__" ||
-            name === "constructor" ||
-            name === "prototype"
-        ) {
-            continue;
-        }
-
-        safeProfiles[name] = sanitizeSettings(profile || {});
-    }
+    const safeProfiles = sanitizeBackupProfiles(importedBackup.profiles);
 
     settingsStore.saveProfiles(safeProfiles);
 
@@ -2216,3 +2222,7 @@ app.on("window-all-closed", () => {
     app.quit();
   }
 });
+
+module.exports = {
+  _sanitizeBackupProfiles: sanitizeBackupProfiles
+};

--- a/test/settingsStore.test.js
+++ b/test/settingsStore.test.js
@@ -7,6 +7,43 @@ const {
   sanitizeSettings
 } = require("../settingsStore");
 
+const Module = require("module");
+const originalRequire = Module.prototype.require;
+Module.prototype.require = function (id) {
+  if (id === "electron") {
+    return {
+      app: {
+        getVersion: () => "0.0.0-test",
+        requestSingleInstanceLock: () => true,
+        whenReady: () => ({ then: () => {} }),
+        on: () => {},
+        quit: () => {},
+        isPackaged: false
+      },
+      BrowserWindow: { getFocusedWindow: () => null },
+      ipcMain: { handle: () => {}, on: () => {} },
+      Menu: {},
+      Tray: function Tray() {},
+      nativeImage: {},
+      screen: {},
+      shell: {},
+      dialog: {},
+      nativeTheme: {},
+      systemPreferences: {},
+      powerMonitor: {},
+      globalShortcut: {}
+    };
+  }
+
+  if (id === "electron-updater") {
+    return { autoUpdater: { checkForUpdatesAndNotify: () => {} } };
+  }
+
+  return originalRequire.apply(this, arguments);
+};
+const { _sanitizeBackupProfiles } = require("../main");
+Module.prototype.require = originalRequire;
+
 test("settingsStore - Default Settings Creation", () => {
   const defaults = createDefaultSettings();
   assert.ok(defaults.onboardingSeen === false);
@@ -150,5 +187,42 @@ test("settingsStore - Focus Mode sanitization and clamping", () => {
   assert.strictEqual(sanitizedMin.focusMode.dimOpacity, 0);
   assert.strictEqual(sanitizedMin.focusMode.idleTimeout, 1);
   assert.strictEqual(sanitizedMin.focusMode.transitionDuration, 0.1);
+});
+
+test("settings backup import profiles - validates names and sanitizes valid profiles", () => {
+  const importedProfiles = JSON.parse(`{
+    "Clean Profile": {
+      "selectedTheme": "sideBars",
+      "sideBars": {
+        "customThickness": 100,
+        "customGap": 0,
+        "customSensitivity": -50
+      }
+    },
+    "bad/profile:name": {
+      "selectedTheme": "reactiveBorder"
+    },
+    "__proto__": {
+      "selectedTheme": "auroraDrift"
+    },
+    "constructor": {
+      "selectedTheme": "flowBorder"
+    },
+    "prototype": {
+      "selectedTheme": "dotParticles"
+    }
+  }`);
+
+  const safeProfiles = _sanitizeBackupProfiles(importedProfiles);
+
+  assert.deepStrictEqual(Object.keys(safeProfiles), ["Clean Profile"]);
+  assert.strictEqual(safeProfiles["Clean Profile"].selectedTheme, "sideBars");
+  assert.strictEqual(safeProfiles["Clean Profile"].sideBars.customThickness, 20);
+  assert.strictEqual(safeProfiles["Clean Profile"].sideBars.customGap, 2);
+  assert.strictEqual(safeProfiles["Clean Profile"].sideBars.customSensitivity, 1);
+  assert.strictEqual(Object.prototype.hasOwnProperty.call(safeProfiles, "bad/profile:name"), false);
+  assert.strictEqual(Object.prototype.hasOwnProperty.call(safeProfiles, "__proto__"), false);
+  assert.strictEqual(Object.prototype.hasOwnProperty.call(safeProfiles, "constructor"), false);
+  assert.strictEqual(Object.prototype.hasOwnProperty.call(safeProfiles, "prototype"), false);
 });
 


### PR DESCRIPTION
## Description

Validate theme profile names during full settings backup import.

Previously, backup import only filtered reserved keys such as `__proto__`, `constructor`, and `prototype`. Other invalid profile names could still be imported and saved into `themeProfiles.json`, causing profiles to appear in the Settings dropdown while failing later profile operations that rely on `isValidProfileName()`.

This change reuses the existing profile name validation during backup import, skips invalid profile names, preserves existing prototype-pollution protections, and continues sanitizing valid imported profile settings.

## Related Issue

Fixes #286

## Changes Made

* Added `sanitizeBackupProfiles()` helper to centralize backup profile sanitization.
* Reused the existing `isValidProfileName()` validation logic during backup import.
* Continued rejecting `__proto__`, `constructor`, and `prototype`.
* Skipped invalid profile names instead of importing them.
* Preserved sanitization of valid imported profile settings.
* Added tests covering:

  * Valid profile imports.
  * Invalid profile name rejection.
  * Reserved key rejection.
  * Sanitization of imported profile settings.

## Testing

```bash
npm.cmd test
git diff --check
```

Results:

* 15/15 tests passed.
* `git diff --check` passed (only line-ending warnings were reported).

## Screenshots

Not applicable (no UI changes).