### PR TITLE
Fix: Make WASAPI loopback buffer size adaptive to device capabilities

### DIFF
--- a/audio-helper/Program.cs
+++ b/audio-helper/Program.cs
@@ -123,11 +123,14 @@ internal sealed class WasapiLoopbackCapture : IDisposable
         (_sampleFormat, _bytesPerSample) = DetectSampleFormat(_mixFormatPointer, _mixFormat);
         _channelCount = _mixFormat.nChannels;
 
+        Marshal.ThrowExceptionForHR(_audioClient.GetDevicePeriod(out var defaultPeriod, out var minimumPeriod));
+        var bufferDuration = Math.Max(minimumPeriod, TimeSpan.FromMilliseconds(10).Ticks);
+
         Marshal.ThrowExceptionForHR(
             _audioClient.Initialize(
                 AudioClientShareMode.Shared,
                 AudioClientStreamFlags.Loopback,
-                0,
+                bufferDuration,
                 0,
                 _mixFormatPointer,
                 IntPtr.Zero));


### PR DESCRIPTION
## Summary
Fixes the WASAPI loopback buffer being hardcoded to a fixed size that's incompatible with high-performance audio devices. The buffer duration is now dynamically determined based on the device's minimum supported period with a 10ms floor.

## Changes
- Modified `WasapiLoopbackCapture` constructor to query device period capabilities via `GetDevicePeriod`
- Compute buffer duration as `Math.Max(minimumPeriod, 10ms)` to adapt to hardware capabilities
- Pass computed duration to `AudioClient.Initialize` instead of fixed 0

## Testing
Verified on high-performance audio interfaces that visualization no longer exhibits stuttering artifacts. The buffer now respects device latency constraints while maintaining compatibility across different hardware setups.

## Related
Closes #331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio loopback capture initialization by adapting buffer sizing to the device’s minimum supported period.
  * Increased reliability across devices while maintaining a minimum 10 ms capture buffer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->