### PR TITLE
Stop ThemeAgent interval on app quit

### DIFF
--- a/main.js
+++ b/main.js
@@ -2381,6 +2381,10 @@ app.on("before-quit", () => {
   destroyAllOverlayWindows();
   stopFocusModePolling();
 
+  if (themeAgent) {
+    themeAgent.stop();
+  }
+
   if (wallpaperPollInterval) {
     clearInterval(wallpaperPollInterval);
     wallpaperPollInterval = null;


### PR DESCRIPTION
Closes Issue #278 


## Problem

`ThemeAgent` starts a `setInterval` in `main.js` during app startup (line 1991), but its `stop()` method was never called in any of the Electron quit lifecycle handlers (`before-quit`, `will-quit`, or `window-all-closed`).

This meant that when the user quits the app (e.g., via tray menu → Quit App), the interval timer could fire one or more times during the shutdown sequence, causing:

1. A spurious `[ThemeAgent] Switching theme to: ...` console log line to appear after the user intended to quit.
2. A slight delay in process exit while the callback executes.
3. A minor inconsistency in cleanup — every other polling mechanism (wallpaper poll interval, focus mode polling, audio bridge) was properly stopped, but ThemeAgent was not.

## Root Cause

In `main.js`, the `themeAgent` variable is declared at module scope (line 26) and started at line 1991:

```js
themeAgent = new ThemeAgent(settingsStore, (themeName) => {
  updateSettings({ selectedTheme: themeName });
});
themeAgent.start();
```

The `before-quit` handler (line 2378) cleaned up `wallpaperPollInterval`, `audioBridge`, and called `stopFocusModePolling()` and `destroyAllOverlayWindows()`, but had no call to `themeAgent.stop()`.

## Fix

Added a `themeAgent.stop()` call in the `before-quit` handler, with a null guard:

```js
if (themeAgent) {
  themeAgent.stop();
}
```

`before-quit` was chosen because:
- It fires early in the shutdown sequence, before any window destruction.
- `themeAgent` does not depend on any window or DOM — it only reads a settings file and calls a callback — so stopping it here is safe and clean.
- The other polling mechanisms are already cleaned up here, making it the idiomatic location.

The `ThemeAgent.stop()` method (in `themeAgent.js:38-42`) already safely handles the case where the interval is `null` or already stopped, so the null guard on `themeAgent` itself is sufficient:

```js
stop() {
  if (this.intervalId) {
    clearInterval(this.intervalId);
    this.intervalId = null;
  }
}
```

## Testing

1. Enable Theme Automation in Settings.
2. Set a short check interval (e.g., 1 minute).
3. Quit the app via tray menu → Quit App.
4. Observe that no `[ThemeAgent]` log lines appear after the quit command, and the process exits promptly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application shutdown by ensuring the theme service stops cleanly when the app exits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->