### PR TITLE
fix(renderer): pause canvas loop while hidden

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
     <script src="themes/sideBraids.js"></script>
     <script src="themes/auroraDrift.js"></script>
     <script src="themes/crimsonDusk.js"></script>
+    <script src="rendererLoop.js"></script>
     <script src="renderer.js"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "files": [
       "main.js",
       "renderer.js",
+      "rendererLoop.js",
       "preload.js",
       "audioBridge.js",
       "settingsStore.js",

--- a/renderer.js
+++ b/renderer.js
@@ -237,7 +237,6 @@ const debugEnabled = params.get("debug") === "1";
 
 // Cleanup tracking variables
 let debugIntervalId = null;
-let animationFrameId = null;
 let resizeHandler = null;
 
 const ADAPTIVE_FALLBACK_ACCENT = "#4facfe";
@@ -705,11 +704,7 @@ function updateColorModulation(now, deltaMs) {
 }
 
 function renderFrame(now) {
-  animationFrameId = requestAnimationFrame(renderFrame);
-
   if (visualizerState.hidden) {
-    context.clearRect(0, 0, width, height);
-    lastFrameAt = performance.now();
     return;
   }
 
@@ -969,7 +964,17 @@ function applySettings(nextSettings) {
 
 
   rebuildCachedPaint();
+  rendererLoop.setHidden(visualizerState.hidden);
 }
+
+const rendererLoop = createRendererLoop({
+  renderFrame,
+  clearCanvas: () => context.clearRect(0, 0, width, height),
+  resetTiming: () => {
+    lastFrameAt = 0;
+  },
+  initialHidden: visualizerState.hidden
+});
 
 resizeHandler = resizeCanvas;
 window.addEventListener("resize", resizeHandler);
@@ -1017,11 +1022,8 @@ function cleanupResources() {
     debugIntervalId = null;
   }
   
-  // Cancel animation frame
-  if (animationFrameId) {
-    cancelAnimationFrame(animationFrameId);
-    animationFrameId = null;
-  }
+  // Cancel animation rendering and prevent it from restarting
+  rendererLoop.destroy();
   
   // Remove resize event listener
   if (resizeHandler) {
@@ -1052,7 +1054,7 @@ if (debugEnabled) {
 }
 
 resizeCanvas();
-animationFrameId = requestAnimationFrame(renderFrame);
+rendererLoop.start();
 
 // --- macOS Glassmorphic Context Menu Integration ---
 

--- a/rendererLoop.js
+++ b/rendererLoop.js
@@ -1,0 +1,93 @@
+(function (globalScope) {
+  function createRendererLoop({
+    renderFrame,
+    clearCanvas,
+    resetTiming,
+    initialHidden = false,
+    requestFrame = globalScope.requestAnimationFrame.bind(globalScope),
+    cancelFrame = globalScope.cancelAnimationFrame.bind(globalScope)
+  }) {
+    let animationFrameId = null;
+    let hidden = initialHidden;
+    let started = false;
+    let destroyed = false;
+
+    function scheduleFrame() {
+      if (destroyed || !started || hidden || animationFrameId !== null) {
+        return;
+      }
+
+      let scheduledFrameId = null;
+      scheduledFrameId = requestFrame((now) => handleFrame(scheduledFrameId, now));
+      animationFrameId = scheduledFrameId;
+    }
+
+    function handleFrame(frameId, now) {
+      if (animationFrameId !== frameId) {
+        return;
+      }
+
+      animationFrameId = null;
+
+      if (destroyed || !started || hidden) {
+        return;
+      }
+
+      renderFrame(now);
+      scheduleFrame();
+    }
+
+    function cancelPendingFrame() {
+      if (animationFrameId === null) {
+        return;
+      }
+
+      cancelFrame(animationFrameId);
+      animationFrameId = null;
+    }
+
+    return {
+      start() {
+        if (destroyed || started) {
+          return;
+        }
+
+        started = true;
+        scheduleFrame();
+      },
+
+      setHidden(nextHidden) {
+        const normalizedHidden = Boolean(nextHidden);
+        if (destroyed || normalizedHidden === hidden) {
+          return;
+        }
+
+        hidden = normalizedHidden;
+        if (hidden) {
+          cancelPendingFrame();
+          clearCanvas();
+          return;
+        }
+
+        resetTiming();
+        scheduleFrame();
+      },
+
+      destroy() {
+        if (destroyed) {
+          return;
+        }
+
+        destroyed = true;
+        started = false;
+        cancelPendingFrame();
+      }
+    };
+  }
+
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = { createRendererLoop };
+  } else {
+    globalScope.createRendererLoop = createRendererLoop;
+  }
+})(typeof globalThis !== "undefined" ? globalThis : window);

--- a/test/rendererLoop.test.js
+++ b/test/rendererLoop.test.js
@@ -1,0 +1,155 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { createRendererLoop } = require("../rendererLoop");
+
+function createHarness(initialHidden = false, onRender) {
+  let nextFrameId = 1;
+  const pendingFrames = new Map();
+  const frameCallbacks = new Map();
+  const requestedFrameIds = [];
+  const cancelledFrameIds = [];
+  const renderedAt = [];
+  let clearCount = 0;
+  let timingResetCount = 0;
+  let loop;
+
+  loop = createRendererLoop({
+    initialHidden,
+    requestFrame(callback) {
+      const id = nextFrameId++;
+      requestedFrameIds.push(id);
+      pendingFrames.set(id, callback);
+      frameCallbacks.set(id, callback);
+      return id;
+    },
+    cancelFrame(id) {
+      cancelledFrameIds.push(id);
+      pendingFrames.delete(id);
+    },
+    renderFrame(now) {
+      renderedAt.push(now);
+      if (onRender) onRender(loop);
+    },
+    clearCanvas() {
+      clearCount += 1;
+    },
+    resetTiming() {
+      timingResetCount += 1;
+    }
+  });
+
+  return {
+    loop,
+    pendingFrames,
+    frameCallbacks,
+    requestedFrameIds,
+    cancelledFrameIds,
+    renderedAt,
+    get clearCount() { return clearCount; },
+    get timingResetCount() { return timingResetCount; },
+    runFrame(id, now) {
+      const callback = pendingFrames.get(id);
+      assert.ok(callback, `expected frame ${id} to be pending`);
+      pendingFrames.delete(id);
+      callback(now);
+    }
+  };
+}
+
+test("visible rendering starts once and keeps one frame pending", () => {
+  const harness = createHarness();
+  harness.loop.start();
+  harness.loop.start();
+
+  assert.deepEqual(harness.requestedFrameIds, [1]);
+  harness.runFrame(1, 100);
+  assert.deepEqual(harness.renderedAt, [100]);
+  assert.deepEqual(harness.requestedFrameIds, [1, 2]);
+  assert.equal(harness.pendingFrames.size, 1);
+});
+
+test("hiding cancels rendering and clears exactly once", () => {
+  const harness = createHarness();
+  harness.loop.start();
+  harness.loop.setHidden(true);
+  harness.loop.setHidden(true);
+
+  assert.deepEqual(harness.cancelledFrameIds, [1]);
+  assert.equal(harness.clearCount, 1);
+  assert.equal(harness.pendingFrames.size, 0);
+});
+
+test("showing resets timing and restarts rendering exactly once", () => {
+  const harness = createHarness();
+  harness.loop.start();
+  harness.loop.setHidden(true);
+  harness.loop.setHidden(false);
+  harness.loop.setHidden(false);
+
+  assert.equal(harness.timingResetCount, 1);
+  assert.deepEqual(harness.requestedFrameIds, [1, 2]);
+  assert.equal(harness.pendingFrames.size, 1);
+});
+
+test("a visualizer that starts hidden remains idle until shown", () => {
+  const harness = createHarness(true);
+  harness.loop.start();
+
+  assert.equal(harness.pendingFrames.size, 0);
+  harness.loop.setHidden(false);
+  assert.equal(harness.timingResetCount, 1);
+  assert.deepEqual(harness.requestedFrameIds, [1]);
+});
+
+test("rapid toggles leave at most one pending frame", () => {
+  const harness = createHarness();
+  harness.loop.start();
+  harness.loop.setHidden(true);
+  harness.loop.setHidden(false);
+  harness.loop.setHidden(true);
+  harness.loop.setHidden(false);
+
+  assert.deepEqual([...harness.pendingFrames.keys()], [3]);
+  assert.deepEqual(harness.cancelledFrameIds, [1, 2]);
+  assert.equal(harness.clearCount, 2);
+  assert.equal(harness.timingResetCount, 2);
+});
+
+test("a stale cancelled callback cannot create a duplicate loop", () => {
+  const harness = createHarness();
+  harness.loop.start();
+  const staleCallback = harness.frameCallbacks.get(1);
+
+  harness.loop.setHidden(true);
+  harness.loop.setHidden(false);
+  staleCallback(50);
+
+  assert.deepEqual(harness.renderedAt, []);
+  assert.deepEqual(harness.requestedFrameIds, [1, 2]);
+  assert.deepEqual([...harness.pendingFrames.keys()], [2]);
+});
+
+test("hiding while a callback runs prevents rescheduling", () => {
+  const harness = createHarness(false, (loop) => loop.setHidden(true));
+  harness.loop.start();
+  harness.runFrame(1, 42);
+
+  assert.deepEqual(harness.renderedAt, [42]);
+  assert.equal(harness.pendingFrames.size, 0);
+  assert.equal(harness.clearCount, 1);
+});
+
+test("cleanup cancels the active frame and prevents restart", () => {
+  const harness = createHarness();
+  harness.loop.start();
+  harness.loop.destroy();
+  harness.loop.destroy();
+  harness.loop.setHidden(true);
+  harness.loop.setHidden(false);
+  harness.loop.start();
+
+  assert.deepEqual(harness.cancelledFrameIds, [1]);
+  assert.equal(harness.pendingFrames.size, 0);
+  assert.deepEqual(harness.requestedFrameIds, [1]);
+});


### PR DESCRIPTION
## Summary

Closes #354

Pauses the renderer animation loop when the visualizer is hidden, preventing unnecessary `requestAnimationFrame` callbacks and repeated canvas clearing while no visual output is displayed.

## Changes Made

* Added a focused renderer loop controller to manage the animation-frame lifecycle.
* Stops scheduling animation frames while the visualizer is hidden.
* Clears the canvas once when transitioning from visible to hidden.
* Restarts rendering when the visualizer becomes visible again.
* Resets timing state on resume so animations continue smoothly.
* Prevents duplicate loops and ignores stale cancelled callbacks.
* Integrates loop shutdown with the existing renderer cleanup.
* Includes the new runtime file in packaged builds.
* Adds focused tests for start, hide, show, rapid toggling, stale callbacks, and cleanup.

## Root Cause

`renderFrame()` scheduled its next animation frame before checking `visualizerState.hidden`.

As a result, hiding the visualizer did not stop the renderer loop. The callback continued running and calling `context.clearRect()` at approximately the display refresh rate.

## Testing

The following checks passed:

```bash
npm.cmd test
node --check rendererLoop.js
node --check renderer.js
node --check test/rendererLoop.test.js
git diff --check
```

Test results:

* 30 tests passed
* 0 tests failed

Manual testing was also completed using:

```bash
npm.cmd start
```

Verified that:

* The visualizer renders normally while visible.
* Hiding stops continuous rendering.
* The canvas is cleared when hidden.
* Showing the visualizer restarts rendering.
* Animations resume smoothly.
* Repeated hide/show actions do not create duplicate loops.

## Files Changed

* `renderer.js`
* `rendererLoop.js`
* `index.html`
* `package.json`
* `test/rendererLoop.test.js`