### PR TITLE
fix(audio-helper): poll wallpaper only in adaptive mode

### DIFF
--- a/audio-helper/Program.cs
+++ b/audio-helper/Program.cs
@@ -13,6 +13,9 @@ internal static class Program
     {
         WasapiLoopbackCapture? capture = null;
         DateTime lastWallpaperCheck = DateTime.MinValue;
+        bool wasWallpaperPollingEnabled = false;
+
+        WallpaperPollingControl.StartReading();
 
         while (true)
         {
@@ -34,12 +37,17 @@ internal static class Program
 
                 Console.WriteLine(payload);
 
-                // Periodically check wallpaper (every 5 seconds)
-                if ((DateTime.Now - lastWallpaperCheck).TotalSeconds >= 5)
+                bool wallpaperPollingEnabled = WallpaperPollingControl.Enabled;
+                if (!wallpaperPollingEnabled)
+                {
+                    lastWallpaperCheck = DateTime.MinValue;
+                }
+                // Check immediately when enabled, then every 5 seconds while enabled.
+                else if (!wasWallpaperPollingEnabled || (DateTime.Now - lastWallpaperCheck).TotalSeconds >= 5)
                 {
                     lastWallpaperCheck = DateTime.Now;
                     var colors = WallpaperColorExtractor.GetWallpaperColors();
-                    if (colors != null)
+                    if (colors != null && WallpaperPollingControl.Enabled)
                     {
                         var colorsPayload = JsonSerializer.Serialize(new
                         {
@@ -49,6 +57,7 @@ internal static class Program
                         Console.WriteLine(colorsPayload);
                     }
                 }
+                wasWallpaperPollingEnabled = wallpaperPollingEnabled;
 
                 Thread.Sleep(33);
             }
@@ -74,6 +83,54 @@ internal static class Program
                 // Wait 1 second before attempting to bind to the new default audio endpoint
                 Thread.Sleep(1000);
             }
+        }
+    }
+}
+
+internal static class WallpaperPollingControl
+{
+    private static int _enabled;
+
+    internal static bool Enabled => Volatile.Read(ref _enabled) == 1;
+
+    internal static void StartReading()
+    {
+        _ = Task.Run(ReadCommands);
+    }
+
+    private static void ReadCommands()
+    {
+        string? line;
+        while ((line = Console.ReadLine()) != null)
+        {
+            TryApplyCommand(line);
+        }
+    }
+
+    internal static bool TryApplyCommand(string line)
+    {
+        try
+        {
+            using JsonDocument document = JsonDocument.Parse(line);
+            JsonElement root = document.RootElement;
+            if (
+                root.ValueKind != JsonValueKind.Object ||
+                !root.TryGetProperty("type", out JsonElement type) ||
+                type.ValueKind != JsonValueKind.String ||
+                type.GetString() != "wallpaper-enabled" ||
+                !root.TryGetProperty("value", out JsonElement value) ||
+                (value.ValueKind != JsonValueKind.True && value.ValueKind != JsonValueKind.False)
+            )
+            {
+                return false;
+            }
+
+            Volatile.Write(ref _enabled, value.GetBoolean() ? 1 : 0);
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
         }
     }
 }

--- a/audioBridge.js
+++ b/audioBridge.js
@@ -31,6 +31,51 @@ function createAudioBridge(sendLevel, onStatusChange = () => {}, sendColors = ()
   let recoveryTimer = null;
   let retryTimer = null;
   let successStartTime = null;
+  let wallpaperPollingEnabled = false;
+  let lastSentWallpaperPollingEnabled = null;
+
+  function syncWallpaperPollingState() {
+    if (lastSentWallpaperPollingEnabled === wallpaperPollingEnabled) {
+      return;
+    }
+
+    const processStdin = helperProcess && helperProcess.stdin;
+    if (
+      !processStdin ||
+      processStdin.destroyed ||
+      processStdin.writable === false ||
+      processStdin.writableEnded
+    ) {
+      return;
+    }
+
+    const sentValue = wallpaperPollingEnabled;
+    const payload = JSON.stringify({
+      type: "wallpaper-enabled",
+      value: sentValue
+    }) + "\n";
+
+    try {
+      lastSentWallpaperPollingEnabled = sentValue;
+      processStdin.write(payload, (error) => {
+        if (
+          error &&
+          helperProcess &&
+          helperProcess.stdin === processStdin &&
+          lastSentWallpaperPollingEnabled === sentValue
+        ) {
+          lastSentWallpaperPollingEnabled = null;
+        }
+      });
+    } catch {
+      lastSentWallpaperPollingEnabled = null;
+    }
+  }
+
+  function setColorMode(mode) {
+    wallpaperPollingEnabled = mode === "wallpaper";
+    syncWallpaperPollingState();
+  }
 
   function updateStatus(nextStatus) {
     if (
@@ -83,8 +128,19 @@ function createAudioBridge(sendLevel, onStatusChange = () => {}, sendColors = ()
 
     helperProcess = spawn(helperBinary, [], {
       windowsHide: true,
-      stdio: ["ignore", "pipe", "pipe"]
+      stdio: ["pipe", "pipe", "pipe"]
     });
+
+    lastSentWallpaperPollingEnabled = null;
+    if (helperProcess.stdin && typeof helperProcess.stdin.on === "function") {
+      const processStdin = helperProcess.stdin;
+      processStdin.on("error", () => {
+        if (helperProcess && helperProcess.stdin === processStdin) {
+          lastSentWallpaperPollingEnabled = null;
+        }
+      });
+    }
+    syncWallpaperPollingState();
 
     helperProcess.stdout.on("data", (chunk) => {
       stdoutBuffer += chunk.toString();
@@ -319,7 +375,8 @@ function createAudioBridge(sendLevel, onStatusChange = () => {}, sendColors = ()
   return {
     start,
     stop,
-    getStatus
+    getStatus,
+    setColorMode
   };
 }
 

--- a/main.js
+++ b/main.js
@@ -378,6 +378,13 @@ function reconcileWallpaperPolling() {
   }
 }
 
+function reconcileWallpaperColorSource() {
+  if (audioBridge) {
+    audioBridge.setColorMode(visualizerSettings && visualizerSettings.colorMode);
+  }
+  reconcileWallpaperPolling();
+}
+
 function applyStartupSettings(launchOnStartup) {
   app.setLoginItemSettings({
     openAtLogin: launchOnStartup,
@@ -620,7 +627,7 @@ function updateSettings(nextSettings) {
 
   sendVisualizerSettings();
   refreshTrayMenu();
-  reconcileWallpaperPolling();
+  reconcileWallpaperColorSource();
 }
 
 function togglePaused() {
@@ -865,7 +872,7 @@ function handleAudioBridgeStatusChange(status) {
     stopSimulatedAudioFallback();
   }
   refreshTrayMenu();
-  reconcileWallpaperPolling();
+  reconcileWallpaperColorSource();
 }
 
 function resetCurrentThemeSettings() {
@@ -890,6 +897,7 @@ function resetAllSettings() {
   registerGlobalShortcuts();
   sendVisualizerSettings();
   refreshTrayMenu();
+  reconcileWallpaperColorSource();
 }
 // Reserved JavaScript property names that must not be used as object keys.
 // Using these as keys on a plain object pollutes Object.prototype and affects
@@ -1967,7 +1975,7 @@ app.whenReady().then(() => {
   visualizerSettings = settingsStore.save(settingsStore.load());
   applyStartupSettings(visualizerSettings.launchOnStartup);
   registerGlobalShortcuts();
-  reconcileWallpaperPolling();
+  reconcileWallpaperColorSource();
 
   if (app.isPackaged) {
     autoUpdater.checkForUpdatesAndNotify();
@@ -2300,6 +2308,7 @@ app.whenReady().then(() => {
       registerGlobalShortcuts();
       sendVisualizerSettings();
       refreshTrayMenu();
+      reconcileWallpaperColorSource();
 
       return {                                    
         success: true,
@@ -2349,6 +2358,7 @@ app.whenReady().then(() => {
   }, handleAudioBridgeStatusChange, (colors) => {
     updateWallpaperColors(colors);
   });
+  reconcileWallpaperColorSource();
 
   // Defer starting the audio bridge to prevent startup resource contention and SmartScreen lags from blocking Electron initialization
   setTimeout(() => {

--- a/test/audioBridge.test.js
+++ b/test/audioBridge.test.js
@@ -52,6 +52,30 @@ const MAX_BYTES = 64 * 1024;        // mirrors audioBridge default
 const BIG = Buffer.alloc(MAX_BYTES + 1, "x");   // always triggers overflow
 const SMALL = Buffer.from(JSON.stringify({ type: "level", value: 0.5 }) + "\n");
 
+function createFakeHelperProcess({ writable = true, destroyed = false, writableEnded = false } = {}) {
+  const proc = new EventEmitter();
+  const stdin = new EventEmitter();
+  const writes = [];
+
+  stdin.writable = writable;
+  stdin.destroyed = destroyed;
+  stdin.writableEnded = writableEnded;
+  stdin.write = (payload, callback) => {
+    writes.push(payload);
+    if (callback) callback(null);
+    return true;
+  };
+
+  proc.stdin = stdin;
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.kill = () => {
+    proc.killed = true;
+  };
+  proc.writes = writes;
+  return proc;
+}
+
 // ---------------------------------------------------------------------------
 // Test 1 — single overflow calls onOverflow and NOT onKill
 // ---------------------------------------------------------------------------
@@ -197,6 +221,164 @@ test("createAudioBridge - stop clears pending retry timer", () => {
   } finally {
     global.setTimeout = originalSetTimeout;
     global.clearTimeout = originalClearTimeout;
+    fakeHelperExists = false;
+    fakeSpawn = null;
+  }
+});
+
+test("createAudioBridge - sends and deduplicates wallpaper polling state", () => {
+  const spawnedProcesses = [];
+  fakeHelperExists = true;
+  fakeSpawn = () => {
+    const proc = createFakeHelperProcess();
+    spawnedProcesses.push(proc);
+    return proc;
+  };
+
+  try {
+    const bridge = createAudioBridge(() => {});
+
+    assert.doesNotThrow(() => bridge.setColorMode("manual"));
+    bridge.setColorMode("wallpaper");
+    bridge.start();
+
+    assert.deepStrictEqual(spawnedProcesses[0].writes, [
+      '{"type":"wallpaper-enabled","value":true}\n'
+    ]);
+
+    bridge.setColorMode("wallpaper");
+    bridge.setColorMode("manual");
+    bridge.setColorMode("system");
+    bridge.setColorMode("wallpaper");
+
+    assert.deepStrictEqual(spawnedProcesses[0].writes, [
+      '{"type":"wallpaper-enabled","value":true}\n',
+      '{"type":"wallpaper-enabled","value":false}\n',
+      '{"type":"wallpaper-enabled","value":true}\n'
+    ]);
+  } finally {
+    fakeHelperExists = false;
+    fakeSpawn = null;
+  }
+});
+
+test("createAudioBridge - defaults unknown modes to disabled", () => {
+  fakeHelperExists = true;
+  const proc = createFakeHelperProcess();
+  fakeSpawn = () => proc;
+
+  try {
+    const bridge = createAudioBridge(() => {});
+    bridge.setColorMode("adaptive");
+    bridge.setColorMode("unexpected");
+    bridge.start();
+
+    assert.deepStrictEqual(proc.writes, [
+      '{"type":"wallpaper-enabled","value":false}\n'
+    ]);
+  } finally {
+    fakeHelperExists = false;
+    fakeSpawn = null;
+  }
+});
+
+test("createAudioBridge - replays the latest state after helper restart", () => {
+  const originalSetTimeout = global.setTimeout;
+  const originalClearTimeout = global.clearTimeout;
+  const scheduledTimers = [];
+  const spawnedProcesses = [];
+
+  global.setTimeout = (callback, delay) => {
+    const timer = { callback, delay, cleared: false };
+    scheduledTimers.push(timer);
+    return timer;
+  };
+  global.clearTimeout = (timer) => {
+    if (timer) timer.cleared = true;
+  };
+  fakeHelperExists = true;
+  fakeSpawn = () => {
+    const proc = createFakeHelperProcess();
+    spawnedProcesses.push(proc);
+    return proc;
+  };
+
+  try {
+    const bridge = createAudioBridge(() => {});
+    bridge.setColorMode("wallpaper");
+    bridge.start();
+    spawnedProcesses[0].emit("exit", 1);
+    scheduledTimers[0].callback();
+
+    assert.strictEqual(spawnedProcesses.length, 2);
+    assert.deepStrictEqual(spawnedProcesses[1].writes, [
+      '{"type":"wallpaper-enabled","value":true}\n'
+    ]);
+  } finally {
+    global.setTimeout = originalSetTimeout;
+    global.clearTimeout = originalClearTimeout;
+    fakeHelperExists = false;
+    fakeSpawn = null;
+  }
+});
+
+test("createAudioBridge - closed helper stdin does not throw", () => {
+  fakeHelperExists = true;
+  const proc = createFakeHelperProcess({ writable: false, writableEnded: true });
+  fakeSpawn = () => proc;
+
+  try {
+    const bridge = createAudioBridge(() => {});
+    assert.doesNotThrow(() => bridge.start());
+    assert.doesNotThrow(() => bridge.setColorMode("wallpaper"));
+    assert.doesNotThrow(() => proc.stdin.emit("error", new Error("closed")));
+    assert.deepStrictEqual(proc.writes, []);
+  } finally {
+    fakeHelperExists = false;
+    fakeSpawn = null;
+  }
+});
+
+test("createAudioBridge - synchronous stdin write failure does not throw", () => {
+  fakeHelperExists = true;
+  const proc = createFakeHelperProcess();
+  proc.stdin.write = () => {
+    throw new Error("broken pipe");
+  };
+  fakeSpawn = () => proc;
+
+  try {
+    const bridge = createAudioBridge(() => {});
+    assert.doesNotThrow(() => bridge.start());
+    assert.doesNotThrow(() => bridge.setColorMode("wallpaper"));
+  } finally {
+    fakeHelperExists = false;
+    fakeSpawn = null;
+  }
+});
+
+test("createAudioBridge - level and colors stdout messages remain unchanged", () => {
+  const levels = [];
+  const colors = [];
+  fakeHelperExists = true;
+  const proc = createFakeHelperProcess();
+  fakeSpawn = () => proc;
+
+  try {
+    const bridge = createAudioBridge(
+      (value) => levels.push(value),
+      () => {},
+      (value) => colors.push(value)
+    );
+    bridge.start();
+    proc.stdout.emit("data", Buffer.from(
+      '{"type":"level","value":0.75}\n' +
+      '{"type":"colors","value":["#111111","#222222","#333333"]}\n'
+    ));
+
+    assert.deepStrictEqual(levels, [0.75]);
+    assert.deepStrictEqual(colors, [["#111111", "#222222", "#333333"]]);
+  } finally {
     fakeHelperExists = false;
     fakeSpawn = null;
   }


### PR DESCRIPTION
## Description

Closes #353

This PR prevents the C# audio helper from polling and emitting wallpaper colors when wallpaper-adaptive color mode is not active.

Electron now communicates the current color mode to the helper through a newline-delimited JSON stdin command:

```json
{"type":"wallpaper-enabled","value":true}
```

The helper defaults to wallpaper polling being disabled and only queries the Windows wallpaper registry or emits `colors` payloads when the exact `wallpaper` mode is enabled.

## Changes

* Added a stdin control channel between Electron and the C# audio helper.
* Added `setColorMode()` to the audio bridge.
* Stored and replayed the latest wallpaper polling state when the helper starts or restarts.
* Deduplicated repeated control messages for unchanged color modes.
* Added defensive handling for closed, unavailable, or failing helper stdin streams.
* Added asynchronous command reading in the C# helper without blocking audio capture.
* Disabled wallpaper registry checks and color payloads outside wallpaper mode.
* Triggered an immediate wallpaper check when wallpaper mode is enabled.
* Centralized native-helper synchronization and Node.js fallback polling in `reconcileWallpaperColorSource()`.
* Preserved existing audio-level and wallpaper-color stdout message formats.
* Added regression tests for mode changes, restart replay, invalid modes, stdin failures, and stdout parsing.

## Behaviour

* Audio-level updates continue in all color modes.
* Manual, system, missing, and unknown modes disable wallpaper polling.
* Wallpaper mode enables polling immediately and continues at the existing five-second interval.
* Changing color modes does not require restarting the application.
* The latest mode is restored after the audio helper restarts.
* Node.js fallback polling remains active only when wallpaper mode is selected and the native helper is unavailable.
* Native and Node.js wallpaper polling do not run simultaneously.

## Testing

* [x] `dotnet build .\audio-helper\Paraline.AudioBridge.csproj`

  * Passed with 0 warnings and 0 errors.
* [x] `npm.cmd run build:helper`

  * Passed and published the self-contained Windows helper.
* [x] `npm.cmd test`

  * Passed, 28/28 tests.
* [x] `node --check audioBridge.js`
* [x] `node --check main.js`
* [x] `node --check test/audioBridge.test.js`
* [x] `npm.cmd start`

  * Electron launched successfully.
* [x] `git diff --check`

  * Passed. Only informational LF-to-CRLF warnings were shown.

## Files Changed

* `audio-helper/Program.cs`
* `audioBridge.js`
* `main.js`
* `test/audioBridge.test.js`

## Screenshots

Not applicable. This change affects background helper communication and wallpaper polling behaviour without changing the user interface.