### PR TITLE
fix: normalize disabled shortcut values

### DIFF
--- a/settingsStore.js
+++ b/settingsStore.js
@@ -661,15 +661,26 @@ function sanitizeColorModulation(input = {}) {
 
 function sanitizeShortcuts(input) {
   const safeInput = (input && typeof input === "object") ? input : {};
+  const keys = ["togglePause", "toggleHide", "cycleTheme"];
+
   const shortcuts = {
     togglePause: typeof safeInput.togglePause === "string" ? safeInput.togglePause : DEFAULT_SETTINGS.shortcuts.togglePause,
     toggleHide: typeof safeInput.toggleHide === "string" ? safeInput.toggleHide : DEFAULT_SETTINGS.shortcuts.toggleHide,
     cycleTheme: typeof safeInput.cycleTheme === "string" ? safeInput.cycleTheme : DEFAULT_SETTINGS.shortcuts.cycleTheme
   };
 
+  // Normalize any casing/whitespace variant of "none" (e.g. "none", "NONE",
+  // " None ") to the canonical "None" sentinel used to mean "no shortcut
+  // assigned". Without this, Electron may try to register the literal
+  // string as an accelerator and fail instead of leaving the shortcut unset.
+  for (const key of keys) {
+    if (typeof shortcuts[key] === "string" && shortcuts[key].trim().toLowerCase() === "none") {
+      shortcuts[key] = "None";
+    }
+  }
+
   // Resolve duplicates by resetting subsequent duplicate actions to "None"
   const seen = new Set();
-  const keys = ["togglePause", "toggleHide", "cycleTheme"];
   for (const key of keys) {
     const val = shortcuts[key];
     if (val && val !== "None") {

--- a/test/settingsStore.test.js
+++ b/test/settingsStore.test.js
@@ -268,6 +268,36 @@ test("settingsStore - wallpaperColors sanitization", () => {
   assert.deepStrictEqual(sanitized3.wallpaperColors, ["#111111", "#222222", "#333333"]);
 });
 
+test("settingsStore - shortcuts normalize any casing of \"none\" to \"None\"", () => {
+  const input = {
+    selectedTheme: "ambientWave",
+    shortcuts: {
+      togglePause: "none",
+      toggleHide: "NONE",
+      cycleTheme: " NoNe "
+    }
+  };
+  const sanitized = sanitizeSettings(input);
+  assert.strictEqual(sanitized.shortcuts.togglePause, "None");
+  assert.strictEqual(sanitized.shortcuts.toggleHide, "None");
+  assert.strictEqual(sanitized.shortcuts.cycleTheme, "None");
+});
+
+test("settingsStore - shortcuts leave real accelerators and canonical None untouched", () => {
+  const input = {
+    selectedTheme: "ambientWave",
+    shortcuts: {
+      togglePause: "Ctrl+Alt+P",
+      toggleHide: "None",
+      cycleTheme: "Ctrl+Alt+T"
+    }
+  };
+  const sanitized = sanitizeSettings(input);
+  assert.strictEqual(sanitized.shortcuts.togglePause, "Ctrl+Alt+P");
+  assert.strictEqual(sanitized.shortcuts.toggleHide, "None");
+  assert.strictEqual(sanitized.shortcuts.cycleTheme, "Ctrl+Alt+T");
+});
+
 
 test("settings backup import profiles - validates names and sanitizes valid profiles", () => {
   const importedProfiles = JSON.parse(`{
@@ -305,4 +335,3 @@ test("settings backup import profiles - validates names and sanitizes valid prof
   assert.strictEqual(Object.prototype.hasOwnProperty.call(safeProfiles, "constructor"), false);
   assert.strictEqual(Object.prototype.hasOwnProperty.call(safeProfiles, "prototype"), false);
 });
-


### PR DESCRIPTION
## Related Issue

Closes #358

---

## Description

Fixed an issue where shortcut values such as `"none"` or `"NONE"` were treated as valid keyboard accelerators instead of representing a disabled shortcut.

Previously, `sanitizeShortcuts()` only recognized the exact string `"None"` as the disabled shortcut value. If users manually edited `settings.json` and entered `"none"` in a different letter case, the value was preserved and Electron could attempt to register it as an accelerator, leading to registration failures.

This fix normalizes shortcut values during sanitization. Any case variation of `"none"` is now converted to the canonical `"None"` value, ensuring disabled shortcuts are handled consistently. Tests have also been added to verify the normalization behavior.

---

## Changes Made

- Updated `sanitizeShortcuts()` to normalize `"none"` regardless of letter casing.
- Converted values such as `"none"`, `"NONE"`, and `"NoNe"` to `"None"`.
- Preserved existing behavior for valid shortcut accelerators.
- Added unit tests covering case-insensitive `"none"` values.
- Ensured disabled shortcuts are stored consistently.

---

## Steps to Test

1. Open `settings.json`.
2. Set a shortcut as:
   ```json
   {
     "shortcuts": {
       "togglePause": "none"
     }
   }
   ```
3. Save the file and start the application.
4. Verify the shortcut is treated as disabled.
5. Repeat using values like `"NONE"` and `"NoNe"`.
6. Run the test suite and verify the new shortcut normalization tests pass.

---

## Expected Result

- Any case variation of `"none"` is normalized to `"None"`.
- Disabled shortcuts are not registered as Electron accelerators.
- Valid shortcut values continue to work normally.
- All related tests pass successfully.

---

## Files Changed

- `settingsStore.js`
- `test/settingsStore.test.js`

---

## Type of Change

☑️ Bug fix

☐ New feature

☐ Breaking change

☐ Documentation update