### PR TITLE
fix: sanitize loaded theme profiles

### DIFF
--- a/settingsStore.js
+++ b/settingsStore.js
@@ -231,6 +231,17 @@ const VALID_AURORA_DENSITY = new Set(["light", "balanced", "rich"]);
 const VALID_COLOR_MODULATION_MODES = new Set(["amplitude", "beat"]);
 const VALID_THEME_AUTOMATION_MODES = new Set(["dayNight"]);
 
+// Reserved / dangerous keys that must never be used as profile names, since
+// they can shadow or pollute Object.prototype when profiles are later spread
+// or assigned onto plain objects.
+const RESERVED_PROFILE_NAMES = new Set(["__proto__", "constructor", "prototype"]);
+
+// Profile names are restricted to a conservative safe character set
+// (letters, numbers, spaces, underscores, hyphens) with a sane length cap.
+// This matches the validation already applied to imported backup profiles.
+const VALID_PROFILE_NAME_PATTERN = /^[A-Za-z0-9 _-]+$/;
+const MAX_PROFILE_NAME_LENGTH = 100;
+
 function createDefaultSettings() {
   return {
     onboardingSeen: DEFAULT_SETTINGS.onboardingSeen,
@@ -730,6 +741,43 @@ function sanitizeSettings(input = {}) {
   };
 }
 
+// Validates a theme profile name. Rejects non-strings, empty/overlong names,
+// reserved keys that could shadow Object.prototype (__proto__, constructor,
+// prototype), and any characters outside the safe allow-list.
+function isValidProfileName(name) {
+  return typeof name === "string" &&
+    name.length > 0 &&
+    name.length <= MAX_PROFILE_NAME_LENGTH &&
+    !RESERVED_PROFILE_NAMES.has(name) &&
+    VALID_PROFILE_NAME_PATTERN.test(name);
+}
+
+// Sanitizes a saved/imported theme-profiles map: drops entries with invalid
+// or unsafe names, drops entries whose value isn't a plain object, and runs
+// each remaining profile's settings through sanitizeSettings so corrupted or
+// hand-edited data can never reach the renderer.
+function sanitizeProfiles(profiles) {
+  if (profiles === null || typeof profiles !== "object" || Array.isArray(profiles)) {
+    return {};
+  }
+
+  const safeProfiles = {};
+  for (const name of Object.keys(profiles)) {
+    if (!isValidProfileName(name)) {
+      continue;
+    }
+
+    const profile = profiles[name];
+    if (profile === null || typeof profile !== "object" || Array.isArray(profile)) {
+      continue;
+    }
+
+    safeProfiles[name] = sanitizeSettings(profile);
+  }
+
+  return safeProfiles;
+}
+
 function createSettingsStore(userDataPath) {
   const settingsPath = path.join(userDataPath, "settings.json");
   const profilesPath = path.join(userDataPath, "themeProfiles.json");
@@ -813,7 +861,12 @@ function createSettingsStore(userDataPath) {
       if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
         return {};
       }
-      return parsed;
+
+      // The file can be hand-edited outside the app, so treat its contents
+      // as untrusted input: drop unsafe/invalid profile names (e.g.
+      // "__proto__", names with disallowed characters) and sanitize every
+      // remaining profile's settings before they reach the renderer.
+      return sanitizeProfiles(parsed);
     } catch (_error) {
       return {};
     }
@@ -845,5 +898,7 @@ module.exports = {
   createDefaultSettings,
   createThemeDefaults,
   createSettingsStore,
-  sanitizeSettings
+  sanitizeSettings,
+  sanitizeProfiles,
+  isValidProfileName
 };

--- a/test/settingsStore.test.js
+++ b/test/settingsStore.test.js
@@ -1,10 +1,15 @@
 const test = require("node:test");
 const assert = require("node:assert");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
 const {
   DEFAULT_SETTINGS,
   createDefaultSettings,
   createThemeDefaults,
-  sanitizeSettings
+  createSettingsStore,
+  sanitizeSettings,
+  sanitizeProfiles
 } = require("../settingsStore");
 
 const Module = require("module");
@@ -364,4 +369,88 @@ test("settings backup import profiles - validates names and sanitizes valid prof
   assert.strictEqual(Object.prototype.hasOwnProperty.call(safeProfiles, "__proto__"), false);
   assert.strictEqual(Object.prototype.hasOwnProperty.call(safeProfiles, "constructor"), false);
   assert.strictEqual(Object.prototype.hasOwnProperty.call(safeProfiles, "prototype"), false);
+});
+
+test("settingsStore - sanitizeProfiles rejects non-object input", () => {
+  assert.deepStrictEqual(sanitizeProfiles(null), {});
+  assert.deepStrictEqual(sanitizeProfiles(undefined), {});
+  assert.deepStrictEqual(sanitizeProfiles([]), {});
+  assert.deepStrictEqual(sanitizeProfiles("not an object"), {});
+  assert.deepStrictEqual(sanitizeProfiles(42), {});
+});
+
+test("settingsStore - sanitizeProfiles drops invalid names and non-object values, sanitizes the rest", () => {
+  const input = {
+    "Clean Profile": {
+      selectedTheme: "sideBars",
+      sideBars: { customThickness: 100, customGap: 0, customSensitivity: -50 }
+    },
+    "bad/profile:name": { selectedTheme: "reactiveBorder" },
+    "__proto__": { selectedTheme: "auroraDrift" },
+    "constructor": { selectedTheme: "flowBorder" },
+    "prototype": { selectedTheme: "dotParticles" },
+    "": { selectedTheme: "ambientWave" },
+    "Null Value": null,
+    "Array Value": []
+  };
+
+  const safeProfiles = sanitizeProfiles(input);
+
+  assert.deepStrictEqual(Object.keys(safeProfiles), ["Clean Profile"]);
+  assert.strictEqual(safeProfiles["Clean Profile"].selectedTheme, "sideBars");
+  assert.strictEqual(safeProfiles["Clean Profile"].sideBars.customThickness, 20);
+  assert.strictEqual(safeProfiles["Clean Profile"].sideBars.customGap, 2);
+  assert.strictEqual(safeProfiles["Clean Profile"].sideBars.customSensitivity, 1);
+});
+
+test("settingsStore - loadProfiles sanitizes profiles read from themeProfiles.json on disk", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "paraline-test-"));
+  try {
+    const store = createSettingsStore(tmpDir);
+
+    const rawProfiles = {
+      "Clean Profile": {
+        selectedTheme: "sideBars",
+        sideBars: { customThickness: 100, customGap: 0, customSensitivity: -50 }
+      },
+      "bad/profile:name": { selectedTheme: "reactiveBorder" },
+      "__proto__": { selectedTheme: "auroraDrift" },
+      "constructor": { selectedTheme: "flowBorder" },
+      "prototype": { selectedTheme: "dotParticles" }
+    };
+
+    fs.mkdirSync(path.dirname(store.profilesPath), { recursive: true });
+    fs.writeFileSync(store.profilesPath, JSON.stringify(rawProfiles, null, 2));
+
+    const safeProfiles = store.loadProfiles();
+
+    assert.deepStrictEqual(Object.keys(safeProfiles), ["Clean Profile"]);
+    assert.strictEqual(safeProfiles["Clean Profile"].selectedTheme, "sideBars");
+    assert.strictEqual(safeProfiles["Clean Profile"].sideBars.customThickness, 20);
+    assert.strictEqual(safeProfiles["Clean Profile"].sideBars.customGap, 2);
+    assert.strictEqual(safeProfiles["Clean Profile"].sideBars.customSensitivity, 1);
+    assert.strictEqual(Object.prototype.hasOwnProperty.call(safeProfiles, "bad/profile:name"), false);
+    assert.strictEqual(Object.prototype.hasOwnProperty.call(safeProfiles, "__proto__"), false);
+    assert.strictEqual(Object.prototype.hasOwnProperty.call(safeProfiles, "constructor"), false);
+    assert.strictEqual(Object.prototype.hasOwnProperty.call(safeProfiles, "prototype"), false);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("settingsStore - loadProfiles returns {} when file is missing or corrupted", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "paraline-test-"));
+  try {
+    const store = createSettingsStore(tmpDir);
+
+    // No file on disk yet.
+    assert.deepStrictEqual(store.loadProfiles(), {});
+
+    // Corrupted JSON should also fall back to {}.
+    fs.mkdirSync(path.dirname(store.profilesPath), { recursive: true });
+    fs.writeFileSync(store.profilesPath, "{ this is not valid json");
+    assert.deepStrictEqual(store.loadProfiles(), {});
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Related Issue

Closes #357

---

## Description

Fixed an issue where theme profiles loaded from `themeProfiles.json` were returned without validation. If the file was manually edited to include invalid profile names or unsafe keys, those profiles could still appear in the application.

This update sanitizes profiles inside `loadProfiles()` before returning them. Invalid profile names such as `__proto__`, `constructor`, empty names, or names containing unsupported characters are skipped. Settings for valid profiles are also sanitized to prevent corrupted configuration data from being loaded. Unit tests have been added to verify the new behavior.

---

## Changes Made

- Added profile sanitization to `loadProfiles()`.
- Skipped invalid profile names (`__proto__`, `constructor`, empty names, and unsupported characters).
- Sanitized settings for each valid profile before returning them.
- Kept existing behavior unchanged for valid profiles.
- Added unit tests covering invalid profile names and malformed profile settings.

---

## Steps to Test

1. Open `themeProfiles.json`.
2. Add an invalid profile such as:
   ```json
   {
     "bad/profile:name": {
       "selectedTheme": "sideBars"
     }
   }
   ```
3. Save the file.
4. Launch the application and open **Settings**.
5. Verify the invalid profile is not displayed.
6. Add a valid profile and confirm it loads successfully.
7. Run the test suite and verify the new tests pass.

---

## Expected Result

- Invalid profile names are ignored during loading.
- Valid profiles are loaded with sanitized settings.
- Unsafe or corrupted profile data does not appear in the Settings UI.
- All related unit tests pass successfully.

---

## Files Changed

- `settingsStore.js`
- `test/settingsStore.test.js`

---

## Type of Change

☑️ Bug fix

☐ New feature

☐ Breaking change

☐ Documentation update