### PR TITLE
perf: add defer attribute to script tags to fix render blocking

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,20 +15,20 @@
     <div id="menu-shield" class="menu-shield hidden"></div>
     <div id="context-menu" class="context-menu hidden"></div>
 
-    <script src="themes/shared.js"></script>
-    <script src="themes/ambientWave.js"></script>
-    <script src="themes/reactiveBorder.js"></script>
-    <script src="themes/flowBorder.js"></script>
-    <script src="themes/sideBars.js"></script>
-    <script src="themes/pulseLines.js"></script>
-    <script src="themes/dotParticles.js"></script>
-    <script src="themes/rippleFlow.js"></script>
-    <script src="themes/snowBubbleParticles.js"></script>
-    <script src="themes/edgeCrystals.js"></script>
-    <script src="themes/sideBraids.js"></script>
-    <script src="themes/auroraDrift.js"></script>
-    <script src="themes/crimsonDusk.js"></script>
-    <script src="rendererLoop.js"></script>
-    <script src="renderer.js"></script>
+    <script src="themes/shared.js" defer></script>
+    <script src="themes/ambientWave.js" defer></script>
+    <script src="themes/reactiveBorder.js" defer></script>
+    <script src="themes/flowBorder.js" defer></script>
+    <script src="themes/sideBars.js" defer></script>
+    <script src="themes/pulseLines.js" defer></script>
+    <script src="themes/dotParticles.js" defer></script>
+    <script src="themes/rippleFlow.js" defer></script>
+    <script src="themes/snowBubbleParticles.js" defer></script>
+    <script src="themes/edgeCrystals.js" defer></script>
+    <script src="themes/sideBraids.js" defer></script>
+    <script src="themes/auroraDrift.js" defer></script>
+    <script src="themes/crimsonDusk.js" defer></script>
+    <script src="rendererLoop.js" defer></script>
+    <script src="renderer.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
This PR resolves issue #408 by adding the defer attribute to the synchronous script tags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page loading by deferring theme and rendering scripts until after the HTML is parsed.
  * Ensured scripts execute in a more predictable order for smoother initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->