### PR TITLE
fix: use non-blocking dialog when settings.json is corrupted

### DIFF
--- a/settingsStore.js
+++ b/settingsStore.js
@@ -817,8 +817,10 @@ function createSettingsStore(userDataPath) {
       try {
         const { app, dialog, Notification } = require("electron");
         if (app && app.isReady()) {
-          // Show dialog warning to user
-          dialog.showMessageBoxSync({
+          // Show dialog warning to user. Use the async dialog.showMessageBox()
+          // so startup is never blocked by a synchronous modal on headless
+          // systems or automated environments.
+          dialog.showMessageBox({
             type: "warning",
             title: "Settings Reset to Defaults",
             message: "Paraline detected a corrupted settings file. Your settings have been reset to defaults.",


### PR DESCRIPTION
## Description

Fixes startup blocking when `settings.json` is corrupted by removing the synchronous modal dialog from the settings load path.

### Changes

* Replaced blocking `dialog.showMessageBoxSync()` with the async `dialog.showMessageBox()` in `settingsStore.load()`.
* Default settings are now returned immediately, so app initialization completes without waiting for user input.
* The corruption warning is shown asynchronously, so startup no longer hangs on headless systems or automated environments.
* Corrupted settings file is still backed up and defaults are still applied.
* Tray/system notification behavior is preserved.

### Related Issue

Closes #405

### Testing

* Verified all 43 unit tests pass with:

```bash
npm test
```

* Verified whitespace and formatting checks:

```bash
git diff --check
```

### Benefits

* App startup no longer blocks when settings.json is corrupted.
* Headless systems and automated environments can launch and initialize without a dismissible dialog.
* Users are still informed about the reset via the async dialog and system notification.




