### PR TITLE
fix: restart simulated audio fallback after visualizer reload

### DIFF
--- a/main.js
+++ b/main.js
@@ -660,6 +660,10 @@ function reloadVisualizer() {
 
   stopSimulatedAudioFallback();
 
+  if (lastBridgeMode !== "helper" && !isQuitting) {
+    startSimulatedAudioFallback();
+  }
+
   for (const overlayWindow of activeOverlayWindows) {
     overlayWindow.webContents.reloadIgnoringCache();
   }


### PR DESCRIPTION
## Description

Fixes the simulated audio fallback being permanently disabled after a visualizer reload by restarting it when the audio helper is still disconnected.

### Changes

* `reloadVisualizer()` now restarts `startSimulatedAudioFallback()` after cleaning up the fallback timer when the helper is not the active bridge mode.
* The restart is guarded by the same conditions used in `handleAudioBridgeStatusChange()` (`lastBridgeMode !== "helper"` and `!isQuitting`), so the fallback stays stopped when the helper is connected or the app is shutting down.
* Visualizers reloaded via the context menu "Reload" option (or any code path calling `reloadVisualizer()`) keep responding to simulated audio when the helper is disconnected.
* Real helper audio behavior is unchanged.

### Related Issue

Closes #399

### Testing

* Verified all 43 unit tests pass with:

```bash
npm test
```

* Verified whitespace and formatting checks:

```bash
git diff --check
```

### Benefits

* Audio reactivity no longer dies permanently after reloading the visualizer while the helper is disconnected.
* The simulated audio fallback resumes immediately after reload instead of requiring a helper reconnect or app restart.
* No behavioral change when the audio helper is connected.
