### PR TITLE
security: add Content-Security-Policy to all renderer pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com" />
     <title>Paraline</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/onboarding.html
+++ b/onboarding.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com" />
     <title>Welcome to Paraline</title>
     <link rel="stylesheet" href="onboarding-styles.css" />
   </head>

--- a/settings.html
+++ b/settings.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com">
     <title>Paraline Settings</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Description

Fixes the missing Content-Security-Policy on all three renderer pages by adding a strict CSP meta tag that restricts sources to `'self'` and blocks inline script execution.

### Changes

* Added a CSP meta tag to `index.html`, `settings.html`, and `onboarding.html`.
* `default-src 'self'` restricts all resource loading to local files.
* `script-src 'self'` blocks inline scripts, inline event handlers, and `eval()`, closing the XSS vector for the `innerHTML`-built context menus and icon SVGs.
* `style-src 'self' 'unsafe-inline'` plus `https://fonts.googleapis.com` keeps the Google Fonts stylesheet and the inline `style` attributes that `settings.html` relies on for its layout working.
* `font-src` allows the Inter font files from `https://fonts.gstatic.com`.
* `img-src 'self' data:` allows the local theme previews and the `data:image/svg+xml` textures used in `styles.css`/`settings.css`.
* `connect-src` preserves the Google Fonts `preconnect` hints.
* Inline styles do not enable script execution in modern engines, so the strict `script-src` remains the effective XSS mitigation while keeping the UI functional.

### Related Issue

Closes #400

### Testing

* Verified all 43 unit tests pass with:

```bash
npm test
```

* Verified whitespace and formatting checks:

```bash
git diff --check
```

* Confirmed no inline scripts, inline event handlers, `javascript:` URIs, or `eval()`/`new Function()` usage exist in any renderer HTML or JavaScript.

### Benefits

* Any future injection vector (e.g., a theme setting rendering user-provided strings) can no longer execute scripts, inline event handlers, or `eval()`.
* Renderer pages are hardened against XSS without breaking the settings UI, Google Fonts, theme previews, or data-URI textures.
* The policy is uniform across all three pages and easy to audit.
