### PR TITLE
Fix contact form validation for name and subject fields

### DIFF
--- a/landing/src/app/api/contact/route.ts
+++ b/landing/src/app/api/contact/route.ts
@@ -18,11 +18,11 @@ export async function POST(request: Request) {
     const { name, email, subject, message } = body;
 
     // Validate presence of required fields first
-    if (!name || !email || !message) {
+    if (!name || !email || !subject || !message) {
       return NextResponse.json(
         {
           success: false,
-          error: "Name, email, and message are required and cannot be empty.",
+          error: "Name, email, subject, and message are required and cannot be empty.",
         },
         { status: 400 }
       );
@@ -47,14 +47,14 @@ export async function POST(request: Request) {
     const trimmedName = name.trim();
     const trimmedEmail = email.trim();
     const trimmedMessage = message.trim();
-    const trimmedSubject = subject ? subject.trim() : "";
+    const trimmedSubject = subject.trim();
 
     // Validate trimmed fields are not empty
-    if (!trimmedName || !trimmedEmail || !trimmedMessage) {
+    if (!trimmedName || !trimmedEmail || !trimmedSubject || !trimmedMessage) {
       return NextResponse.json(
         {
           success: false,
-          error: "Name, email, and message are required and cannot be empty.",
+          error: "Name, email, subject, and message are required and cannot be empty.",
         },
         { status: 400 }
       );
@@ -67,6 +67,18 @@ export async function POST(request: Request) {
         {
           success: false,
           error: "Invalid email format.",
+        },
+        { status: 400 }
+      );
+    }
+
+    const nameRegex = /^[A-Za-z]+(?:[ '-][A-Za-z]+)*$/;
+    if (!nameRegex.test(trimmedName)) {
+      return NextResponse.json(
+        {
+          success: false,
+          error:
+            "Name can only contain letters, spaces, apostrophes, and hyphens.",
         },
         { status: 400 }
       );

--- a/landing/src/app/api/contact/route.ts
+++ b/landing/src/app/api/contact/route.ts
@@ -72,13 +72,13 @@ export async function POST(request: Request) {
       );
     }
 
-    const nameRegex = /^[A-Za-z]+(?:[ '-][A-Za-z]+)*$/;
+    const nameRegex = /^[\p{L}\p{M}]+(?:[ '\-][\p{L}\p{M}]+)*$/u;
     if (!nameRegex.test(trimmedName)) {
       return NextResponse.json(
         {
           success: false,
           error:
-            "Name can only contain letters, spaces, apostrophes, and hyphens.",
+            "Name can only contain letters from any language, spaces, apostrophes, and hyphens.",
         },
         { status: 400 }
       );

--- a/landing/src/app/contact/page.jsx
+++ b/landing/src/app/contact/page.jsx
@@ -157,8 +157,7 @@ export default function ContactPage() {
                     value={form.name}
                     onChange={handleChange}
                     required
-                    pattern="[A-Za-z]+([ '-][A-Za-z]+)*"
-                    title="Name can only contain letters, spaces, apostrophes, and hyphens."
+                    title="Name can only contain letters from any language, spaces, apostrophes, and hyphens."
                     maxLength={100}
                     className="w-full p-4 rounded-2xl bg-[#010206]/40 border border-white/5 text-white outline-none focus:border-cyan-500/40 focus:bg-[#010206]/60 transition-all placeholder:text-white/25 text-sm"
                   />

--- a/landing/src/app/contact/page.jsx
+++ b/landing/src/app/contact/page.jsx
@@ -157,6 +157,8 @@ export default function ContactPage() {
                     value={form.name}
                     onChange={handleChange}
                     required
+                    pattern="[A-Za-z]+([ '-][A-Za-z]+)*"
+                    title="Name can only contain letters, spaces, apostrophes, and hyphens."
                     maxLength={100}
                     className="w-full p-4 rounded-2xl bg-[#010206]/40 border border-white/5 text-white outline-none focus:border-cyan-500/40 focus:bg-[#010206]/60 transition-all placeholder:text-white/25 text-sm"
                   />
@@ -191,6 +193,7 @@ export default function ContactPage() {
                   placeholder="How can we help?"
                   value={form.subject}
                   onChange={handleChange}
+                  required
                   maxLength={200}
                   className="w-full p-4 rounded-2xl bg-[#010206]/40 border border-white/5 text-white outline-none focus:border-cyan-500/40 focus:bg-[#010206]/60 transition-all placeholder:text-white/25 text-sm"
                 />


### PR DESCRIPTION
## Description

Fixes #468 
Closes #468 

This PR fixes validation issues in the Contact Us form.

### Changes made

- Added validation to reject numeric-only values in the Name field.
- Added validation to ensure the Subject field is required.
- Updated frontend validation to prevent invalid submissions.
- Added backend validation to enforce the same rules server-side.

### Testing

- Verified that numeric-only names such as `1234` are rejected.
- Verified that submitting the form without a subject is prevented.
- Verified that valid names and completed forms are submitted successfully.

### Screenshot:

Before:

<img width="810" height="847" alt="image" src="https://github.com/user-attachments/assets/e01ac640-2df0-49b2-9400-79fc3728217c" />


After:

<img width="747" height="795" alt="image" src="https://github.com/user-attachments/assets/d6d94af0-b8ff-436d-8fe5-4ea84ee74c5f" />
