### PR TITLE
fix: add name and subject validation to contact form

### DIFF
--- a/landing/src/app/contact/page.jsx
+++ b/landing/src/app/contact/page.jsx
@@ -54,6 +54,24 @@ export default function ContactPage() {
   const handleSubmit = async (e) => {
     e.preventDefault();
 
+    // Validate name: reject numeric-only input
+    if (/^\d+$/.test(form.name.trim())) {
+      setStatus("❌ Name cannot be numeric-only.");
+      return;
+    }
+
+    // Validate name: must contain at least one letter
+    if (!/[a-zA-Z]/.test(form.name.trim())) {
+      setStatus("❌ Name must contain at least one letter.");
+      return;
+    }
+
+    // Subject is required
+    if (!form.subject.trim()) {
+      setStatus("❌ Subject is required.");
+      return;
+    }
+
     setLoading(true);
     setStatus("");
 


### PR DESCRIPTION
## Description
Add client-side validation to the contact form to reject invalid submissions.

## Changes
- Reject numeric-only names (e.g. "1234")
- Require at least one letter in the name field
- Make subject field required with HTML5 validation
- Show clear error messages before form submission

## Related Issue
Relates to #468

## Type of Change
- [x] Bug fix
- [x] Enhancement
